### PR TITLE
Fix loading embeddings with untied embeddings

### DIFF
--- a/genienlp/data_utils/embeddings.py
+++ b/genienlp/data_utils/embeddings.py
@@ -221,12 +221,12 @@ def load_embeddings(cachedir, context_emb_names, question_emb_names, decoder_emb
             config = AutoConfig.from_pretrained(emb_type, cache_dir=cachedir)
             config.output_hidden_states = True
             if numericalizer is None:
-                if _is_bert(emb_name):
-                    numericalizer = BertNumericalizer(emb_name, config=config,
+                if _is_bert(emb_type):
+                    numericalizer = BertNumericalizer(emb_type, config=config,
                                                       max_generative_vocab=max_generative_vocab,
                                                       cache=cachedir)
-                elif _is_xlmr(emb_name):
-                    numericalizer = XLMRobertaNumericalizer(emb_name, config=config,
+                elif _is_xlmr(emb_type):
+                    numericalizer = XLMRobertaNumericalizer(emb_type, config=config,
                                                             max_generative_vocab=max_generative_vocab,
                                                             cache=cachedir)
                 numericalizer_type = emb_type
@@ -258,12 +258,12 @@ def load_embeddings(cachedir, context_emb_names, question_emb_names, decoder_emb
             config = AutoConfig.from_pretrained(emb_type, cache_dir=cachedir)
             config.output_hidden_states = True
             if numericalizer is None:
-                if _is_bert(emb_name):
-                    numericalizer = BertNumericalizer(emb_name, config=config,
+                if _is_bert(emb_type):
+                    numericalizer = BertNumericalizer(emb_type, config=config,
                                                       max_generative_vocab=max_generative_vocab,
                                                       cache=cachedir)
-                elif _is_xlmr(emb_name):
-                    numericalizer = XLMRobertaNumericalizer(emb_name, config=config,
+                elif _is_xlmr(emb_type):
+                    numericalizer = XLMRobertaNumericalizer(emb_type, config=config,
                                                             max_generative_vocab=max_generative_vocab,
                                                             cache=cachedir)
                 numericalizer_type = emb_type

--- a/genienlp/export.py
+++ b/genienlp/export.py
@@ -53,10 +53,12 @@ def main(args):
 
     # we need to load the embeddings to get to the correct numericalizer class
     # this is somewhat unfortunate but acceptable
-    numericalizer, _, _ = load_embeddings(args.embeddings, args.encoder_embeddings,
-                                          args.decoder_embeddings,
-                                          args.max_generative_vocab,
-                                          logger)
+    numericalizer, _, _, _ = load_embeddings(args.embeddings,
+                                             args.context_embeddings,
+                                             args.question_embeddings,
+                                             args.decoder_embeddings,
+                                             args.max_generative_vocab,
+                                             logger)
 
     # load the numericalizer from the model training directory, and immediately save it in the export directory
     # this will copy over all the necessary vocabulary and config files that the numericalizer needs


### PR DESCRIPTION
If embeddings for context & questions are untied with the "@" suffix,
we must not pass the suffix to the transformer library.