### PR TITLE
A potentially better way to fine-tune BERT for contextual tasks

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ pyrouge = ">=0.1.3"
 sacrebleu = "~=1.0"
 tensorboardX = "==2.0.*"
 requests = "~=2.22"
-transformers = "==2.3.0"
+transformers = "==2.9"
 radam = {git = "https://github.com/LiyuanLucasLiu/RAdam"}
 sentencepiece = ">=0.1.83,<0.2.0"
 

--- a/genienlp/arguments.py
+++ b/genienlp/arguments.py
@@ -175,6 +175,8 @@ def parse_argv(parser):
                         help='probability of replacing a token with mask for MLM pretraining')
     parser.add_argument('--force_subword_tokenize', action='store_true', default=False,
                         help='force subword tokenization of code tokens too')
+    parser.add_argument('--append_question_to_context_too', action='store_true', default=False,
+                        help='')
 
     parser.add_argument('--warmup', default=800, type=int, help='warmup for learning rate')
     parser.add_argument('--grad_clip', default=1.0, type=float, help='gradient clipping')

--- a/genienlp/data_utils/example.py
+++ b/genienlp/data_utils/example.py
@@ -45,13 +45,15 @@ class Example(NamedTuple):
     question_word_mask: List[bool]
     answer: List[str]
     answer_word_mask: List[bool]
+    context_plus_question: List[str]
+    context_plus_question_word_mask: List[bool]
 
     vocab_fields = ['context', 'question', 'answer']
 
     @staticmethod
     def from_raw(example_id: str, context: str, question: str, answer: str, tokenize, lower=False):
         args = [example_id]
-        for argname, arg in (('context', context), ('question', question), ('answer', answer)):
+        for argname, arg in (('context', context), ('question', question), ('answer', answer), ('question', context+' '+question)):
             words, mask = tokenize(arg.rstrip('\n'), field_name=argname)
             if mask is None:
                 mask = [True for _ in words]
@@ -59,6 +61,7 @@ class Example(NamedTuple):
                 words = [word.lower() for word in words]
             args.append(words)
             args.append(mask)
+        
         return Example(*args)
 
 
@@ -70,9 +73,8 @@ class Batch(NamedTuple):
     decoder_vocab: object
     
     @staticmethod
-    def from_examples(examples, numericalizer, device=None, paired=False, max_pairs=None, groups=None):
+    def from_examples(examples, numericalizer, device=None, paired=False, max_pairs=None, groups=None, append_question_to_context_too=False):
         assert all(isinstance(ex.example_id, str) for ex in examples)
-        
         decoder_vocab = numericalizer.decoder_vocab.clone()
         max_context_len, max_question_len, max_answer_len = -1, -1, -1
 
@@ -91,8 +93,13 @@ class Batch(NamedTuple):
             example_pairs = example_pairs[:max_pairs]
             
             example_ids = [ex_a.example_id + '@' + ex_b.example_id for ex_a, ex_b in example_pairs]
-            context_inputs = [((ex_a.context, ex_a.context_word_mask), (ex_b.context, ex_b.context_word_mask)) for ex_a, ex_b in example_pairs]
-            question_inputs = [((ex_a.question, ex_a.question_word_mask), (ex_b.question, ex_b.question_word_mask)) for ex_a, ex_b in example_pairs]
+            if append_question_to_context_too:
+                question_inputs = [((ex_a.question, ex_a.question_word_mask), (ex_b.question, ex_b.question_word_mask)) for ex_a, ex_b in example_pairs]
+                context_inputs = [((ex_a.context_plus_question, ex_a.context_plus_question_word_mask), \
+                                    (ex_b.context_plus_question, ex_b.context_plus_question_word_mask)) for ex_a, ex_b in example_pairs]
+            else:
+                context_inputs = [((ex_a.context, ex_a.context_word_mask), (ex_b.context, ex_b.context_word_mask)) for ex_a, ex_b in example_pairs]
+                question_inputs = [((ex_a.question, ex_a.question_word_mask), (ex_b.question, ex_b.question_word_mask)) for ex_a, ex_b in example_pairs]
             answer_inputs = [((ex_a.answer, ex_a.answer_word_mask), (ex_b.answer, ex_b.answer_word_mask)) for ex_a, ex_b in example_pairs]
 
             all_example_ids_pair = example_ids
@@ -106,8 +113,12 @@ class Batch(NamedTuple):
 
         # process single examples
         example_ids = [ex.example_id for ex in examples]
-        context_inputs = [(ex.context, ex.context_word_mask) for ex in examples]
-        question_inputs = [(ex.question, ex.question_word_mask) for ex in examples]
+        if append_question_to_context_too:
+            question_inputs = [(ex.question, ex.question_word_mask) for ex in examples]
+            context_inputs = [(ex.context_plus_question, ex.context_plus_question_word_mask) for ex in examples]
+        else:
+            context_inputs = [(ex.context, ex.context_word_mask) for ex in examples]
+            question_inputs = [(ex.question, ex.question_word_mask) for ex in examples]
         answer_inputs = [(ex.answer, ex.answer_word_mask) for ex in examples]
         
         all_example_ids_single = example_ids
@@ -125,7 +136,6 @@ class Batch(NamedTuple):
             all_context_inputs = all_context_inputs_single
             all_question_inputs = all_question_inputs_single
             all_answer_inputs = all_answer_inputs_single
-            
         return Batch(all_example_ids,
                      all_context_inputs,
                      all_question_inputs,

--- a/genienlp/data_utils/numericalizer/masked_tokenizer.py
+++ b/genienlp/data_utils/numericalizer/masked_tokenizer.py
@@ -88,6 +88,8 @@ class MaskedBertWordPieceTokenizer(object):
     def tokenize(self, tokens, mask):
         output_tokens = []
         for token, should_word_split in zip(tokens, mask):
+            # if token.startswith('@'):
+            #     token = token.lower()
             if not should_word_split:
                 if token not in self.vocab and token not in self.added_tokens_encoder:
                     token_id = len(self.vocab) + len(self.added_tokens_encoder)

--- a/genienlp/models/general_seq2seq.py
+++ b/genienlp/models/general_seq2seq.py
@@ -91,6 +91,7 @@ class Seq2Seq(torch.nn.Module):
                             final_question, question_rnn_state, encoder_loss)
 
     def forward(self, batch, iteration, pretraining=False):
+        # print('batch = ', batch)
         if pretraining:
             return self._pretrain_forward(batch)
         else:

--- a/genienlp/predict.py
+++ b/genienlp/predict.py
@@ -109,10 +109,10 @@ def run(args, numericalizer, val_sets, model, device):
             task_languages = task_languages.split('+')
             assert len(task_languages) == len(val_set)
             for index, set in enumerate(val_set):
-                task_iter.append((task, task_languages[index],  make_data_loader(set, numericalizer, bs, device)))
+                task_iter.append((task, task_languages[index],  make_data_loader(set, numericalizer, bs, device, append_question_to_context_too=args.append_question_to_context_too)))
         # single language task or no separate eval
         else:
-           task_iter.append((task, task_languages,  make_data_loader(val_set[0], numericalizer, bs, device)))
+           task_iter.append((task, task_languages,  make_data_loader(val_set[0], numericalizer, bs, device, append_question_to_context_too=args.append_question_to_context_too)))
 
         iters.extend(task_iter)
         task_index += 1

--- a/genienlp/run_generation.py
+++ b/genienlp/run_generation.py
@@ -152,8 +152,8 @@ def sample_sequence(model, length, context, position_ids, num_samples=1, tempera
                 inputs['past'] = past
                 if past is not None:
                     inputs['input_ids'] = next_token
-                    inputs['position_ids'] = position_ids[:, next_index-1]
-                    inputs['token_type_ids'] = segment_ids[:, next_index-1]
+                    inputs['position_ids'] = position_ids[:, next_index-1].unsqueeze(-1)
+                    inputs['token_type_ids'] = segment_ids[:, next_index-1].unsqueeze(-1)
             
             outputs = model(**inputs)
             next_token_logits = outputs[0][:, -1, :] / (temperature if temperature > 0 else 1.)

--- a/genienlp/server.py
+++ b/genienlp/server.py
@@ -65,7 +65,7 @@ class Server:
             emb.grow_for_vocab(self.numericalizer.vocab, new_words)
 
         # batch of size 1
-        return Batch.from_examples([ex], self.numericalizer, device=self.device)
+        return Batch.from_examples([ex], self.numericalizer, device=self.device, append_question_to_context_too=self.args.append_question_to_context_too)
 
     def handle_request(self, line):
         request = json.loads(line)

--- a/genienlp/tasks/almond/__init__.py
+++ b/genienlp/tasks/almond/__init__.py
@@ -234,10 +234,7 @@ class AlmondDialogueNLU(BaseAlmondTask):
     state of the conversation)
     """
     def _is_program_field(self, field_name):
-        if self.append_question_to_context_too:
-            return field_name == 'answer'
-        else:
-            return field_name in ('answer', 'context')
+        return field_name in ('answer', 'context')
 
     def _make_example(self, parts, dir_name=None):
         _id, context, sentence, target_code = parts

--- a/genienlp/tasks/almond/__init__.py
+++ b/genienlp/tasks/almond/__init__.py
@@ -110,6 +110,7 @@ class AlmondDataset(CQA):
 def is_entity(token):
     return token[0].isupper()
 
+
 def process_id(ex):
     id_ = ex.example_id.rsplit('/', 1)
     id_ = id_[0] if len(id_) == 1 else id_[1]
@@ -233,7 +234,10 @@ class AlmondDialogueNLU(BaseAlmondTask):
     state of the conversation)
     """
     def _is_program_field(self, field_name):
-        return field_name in ('answer', 'context')
+        if self.append_question_to_context_too:
+            return field_name == 'answer'
+        else:
+            return field_name in ('answer', 'context')
 
     def _make_example(self, parts, dir_name=None):
         _id, context, sentence, target_code = parts

--- a/genienlp/tasks/base_task.py
+++ b/genienlp/tasks/base_task.py
@@ -43,6 +43,7 @@ class BaseTask:
     def __init__(self, name, args):
         self.name = name
         self.force_subword_tokenize = args.force_subword_tokenize
+        self.append_question_to_context_too = args.append_question_to_context_too
 
     @property
     def default_question(self):

--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -341,11 +341,13 @@ def train(args, devices, model, opt, lr_scheduler, train_sets, train_iterations,
 
     logger.info(f'Preparing iterators')
     main_device = devices[0]
-    train_iters = [(task, make_data_loader(x, numericalizer, tok, main_device, paired=args.paired, max_pairs=args.max_pairs, train=True))
+    train_iters = [(task, make_data_loader(x, numericalizer, tok, main_device, paired=args.paired, max_pairs=args.max_pairs, train=True, 
+                   append_question_to_context_too=args.append_question_to_context_too))
                    for task, x, tok in zip(args.train_tasks, train_sets, args.train_batch_values)]
     train_iters = [(task, iter(train_iter)) for task, train_iter in train_iters]
 
-    val_iters = [(task, make_data_loader(x, numericalizer, bs, main_device, train=False, valid=True))
+    val_iters = [(task, make_data_loader(x, numericalizer, bs, main_device, train=False, valid=True,
+                 append_question_to_context_too=args.append_question_to_context_too))
                  for task, x, bs in zip(args.val_tasks, val_sets, args.val_batch_size)]
 
     aux_iters = []

--- a/genienlp/util.py
+++ b/genienlp/util.py
@@ -238,7 +238,7 @@ def elapsed_time(log):
     return f'{day:02}:{hour:02}:{minutes:02}:{seconds:02}'
 
 
-def make_data_loader(dataset, numericalizer, batch_size, device=None, paired=False, max_pairs=None, train=False, valid=False):
+def make_data_loader(dataset, numericalizer, batch_size, device=None, paired=False, max_pairs=None, train=False, valid=False, append_question_to_context_too=False):
     
     iterator = Iterator(dataset,
                         batch_size,
@@ -248,7 +248,8 @@ def make_data_loader(dataset, numericalizer, batch_size, device=None, paired=Fal
                         use_data_sort_key=train)
     
     collate_function = lambda minibatch: Batch.from_examples(minibatch, numericalizer, device=device,
-                                           paired=paired and train, max_pairs=max_pairs, groups=iterator.groups)
+                                           paired=paired and train, max_pairs=max_pairs, groups=iterator.groups, 
+                                           append_question_to_context_too=append_question_to_context_too)
         
     return torch.utils.data.DataLoader(iterator, batch_size=None, collate_fn=collate_function)
 
@@ -281,7 +282,7 @@ def load_config_json(args):
                     'trainable_decoder_embeddings', 'trainable_encoder_embeddings', 'train_encoder_embeddings',
                     'train_context_embeddings', 'train_question_embeddings', 'locale', 'use_pretrained_bert',
                     'train_context_embeddings_after', 'train_question_embeddings_after',
-                    'pretrain_context', 'pretrain_mlm_probability', 'force_subword_tokenize', 'num_beams']
+                    'pretrain_context', 'pretrain_mlm_probability', 'force_subword_tokenize', 'num_beams', 'append_question_to_context_too']
 
         for r in retrieve:
             if r in config:
@@ -318,6 +319,8 @@ def load_config_json(args):
                 setattr(args, r, True)
             elif r == 'num_beams':
                 setattr(args, r, 1)
+            elif r == 'append_question_to_context_too':
+                setattr(args, r, False)
             else:
                 setattr(args, r, None)
         args.dropout_ratio = 0.0

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
         'pyrouge>=0.1.3',
         'sacrebleu~=1.0',
         'requests~=2.22',
-        'transformers~=2.3',
+        'transformers==2.9',
         'sentencepiece>=0.1.83,<0.2.0'
     ]
 )


### PR DESCRIPTION
- Using `--append_question_to_context_too` will append a copy of the question to the end of context, and will tokenize it like a non-program field.
This approach seems effective especially for the `almond_dialogue_nlu` task.
- transformers is updated to version 2.9. Due to changes in model hashes, rebuilding the common docker image might be necessary.