### PR TITLE
Treat device names as special tokens

### DIFF
--- a/genienlp/data_utils/numericalizer/transformer.py
+++ b/genienlp/data_utils/numericalizer/transformer.py
@@ -264,6 +264,9 @@ class XLMRobertaNumericalizer(TransformerNumericalizer):
         def is_entity(token):
             return token[0].isupper()
 
+        def is_device(token):
+            return token[0] == '@'
+
         def reverse_one(tensor, field_name):
             tokens = []
 
@@ -290,7 +293,7 @@ class XLMRobertaNumericalizer(TransformerNumericalizer):
                             tokens.append(token)
 
                     else:
-                        if is_entity(token):
+                        if is_entity(token) or is_device(token):
                             tokens.append(token)
                         else:
                             tokens[-1] += token

--- a/genienlp/tasks/almond/__init__.py
+++ b/genienlp/tasks/almond/__init__.py
@@ -110,6 +110,8 @@ class AlmondDataset(CQA):
 def is_entity(token):
     return token[0].isupper()
 
+def is_device(token):
+    return token[0] == '@'
 
 def process_id(ex):
     id_ = ex.example_id.rsplit('/', 1)
@@ -163,7 +165,7 @@ class BaseAlmondTask(BaseTask):
 
         else:
             tokens = sentence.split(' ')
-            mask = [not is_entity(token) for token in tokens]
+            mask = [not is_entity(token) and not is_device(token) for token in tokens]
             return tokens, mask
 
     def detokenize(self, tokenized, field_name=None):


### PR DESCRIPTION
So that uncased transformer models do not replace them with [UNK] token.