### PR TITLE
[2] Contextual multilingual tasks 

### DIFF
--- a/genienlp/arguments.py
+++ b/genienlp/arguments.py
@@ -214,6 +214,8 @@ def parse_argv(parser):
 
     parser.add_argument('--skip_cache', action='store_true',
                         help='whether to use exisiting cached splits or generate new ones')
+    parser.add_argument('--cache_input_data', action='store_true',
+                        help='Cache examples from input data for faster subsequent trainings')
     parser.add_argument('--use_curriculum', action='store_true', help='Use curriculum learning')
     parser.add_argument('--aux_dataset', default='', type=str,
                         help='path to auxiliary dataset (ignored if curriculum is not used)')

--- a/genienlp/arguments.py
+++ b/genienlp/arguments.py
@@ -179,8 +179,8 @@ def parse_argv(parser):
     parser.add_argument('--append_question_to_context_too', action='store_true', default=False,
                         help='')
     parser.add_argument('--override_question', default=None, help='Override the question for all tasks')
-    parser.add_argument('--almond_preprocess_context', action='store_true', default=False,
-                        help='')
+    parser.add_argument('--override_context', default=None, help='Override the context for all tasks')
+    parser.add_argument('--almond_preprocess_context', action='store_true', default=False, help='')
     parser.add_argument('--almond_lang_as_question', action='store_true',
                         help='if true will use "Translate from ${language} to ThingTalk" for question')
 
@@ -254,6 +254,9 @@ def post_parse(args):
     
     if args.use_encoder_loss and not (args.sentence_batching and len(args.train_languages.split('+')) > 1) :
         raise ValueError('To use encoder loss you must use sentence batching and use more than one language during training.')
+
+    if args.override_context and args.append_question_to_context_too:
+        raise ValueError('You cannot use append_question_to_context_too when overriding context')
     
     if args.paired and not args.sentence_batching:
         logger.warning('Paired training only works if sentence_batching is used as well.'

--- a/genienlp/paraphrase/run_generation.py
+++ b/genienlp/paraphrase/run_generation.py
@@ -418,7 +418,7 @@ def run_single_process_generation(args, config):
                     sample_layer_attention = layer_attention[sample_index, :, :, :]
 
                     if tgt_tokens[0] == tokenizer.pad_token or tgt_tokens[0] == special_tokens['sep_token'] or \
-                            tgt_tokens[0] == tokenizer.id_to_lang_code[decoder_start_token_id]:
+                            (decoder_start_token_id and tgt_tokens[0] == tokenizer.id_to_lang_code[decoder_start_token_id]):
                         # shift target tokens left to match the attention positions
                         tgt_tokens = tgt_tokens[1:]
                     while src_tokens[-1] == tokenizer.pad_token:

--- a/genienlp/predict.py
+++ b/genienlp/predict.py
@@ -137,13 +137,13 @@ def run(args, device):
             for index, set_ in enumerate(val_set):
                 loader = make_data_loader(set_, numericalizer, bs, device,
                                           append_question_to_context_too=args.append_question_to_context_too,
-                                          override_question=args.override_question)
+                                          override_question=args.override_question, override_context=args.override_context)
                 task_iter.append((task, task_languages[index], loader))
         # single language task or no separate eval
         else:
            loader = make_data_loader(val_set[0], numericalizer, bs, device,
                                      append_question_to_context_too=args.append_question_to_context_too,
-                                     override_question=args.override_question)
+                                     override_question=args.override_question, override_context=args.override_context)
            task_iter.append((task, task_languages, loader))
 
         iters.extend(task_iter)

--- a/genienlp/server.py
+++ b/genienlp/server.py
@@ -67,7 +67,8 @@ class Server:
         # batch of size 1
         return Batch.from_examples([ex], self.numericalizer, device=self.device,
                                    append_question_to_context_too=self.args.append_question_to_context_too,
-                                   override_question=self.args.override_question)
+                                   override_question=self.args.override_question,
+                                   override_context=self.args.override_context)
 
     def handle_request(self, line):
         request = json.loads(line)

--- a/genienlp/tasks/almond/__init__.py
+++ b/genienlp/tasks/almond/__init__.py
@@ -55,7 +55,7 @@ class AlmondDataset(CQA):
 
     base_url = None
 
-    def __init__(self, path, *, make_example, subsample=None, cached_path=None, skip_cache=False, **kwargs):
+    def __init__(self, path, *, make_example, subsample=None, cached_path=None, skip_cache=False, cache_input_data=False, **kwargs):
         
         #TODO fix cache_path for multilingual task
         cache_name = os.path.join(cached_path, os.path.basename(path), str(subsample))
@@ -78,8 +78,9 @@ class AlmondDataset(CQA):
                 if len(examples) >= max_examples:
                     break
             os.makedirs(os.path.dirname(cache_name), exist_ok=True)
-            logger.info(f'Caching data to {cache_name}')
-            torch.save(examples, cache_name)
+            if cache_input_data:
+                logger.info(f'Caching data to {cache_name}')
+                torch.save(examples, cache_name)
 
         super().__init__(examples, **kwargs)
         

--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -345,20 +345,20 @@ def train(args, devices, model, opt, lr_scheduler, train_sets, train_iterations,
     train_iters = [(task,
                     make_data_loader(x, numericalizer, tok, main_device, paired=args.paired,max_pairs=args.max_pairs,
                                      train=True,  append_question_to_context_too=args.append_question_to_context_too,
-                                     override_question=args.override_question))
+                                     override_question=args.override_question, override_context=args.override_context))
                    for task, x, tok in zip(args.train_tasks, train_sets, args.train_batch_values)]
     train_iters = [(task, iter(train_iter)) for task, train_iter in train_iters]
 
     val_iters = [(task, make_data_loader(x, numericalizer, bs, main_device, train=False, valid=True,
                                          append_question_to_context_too=args.append_question_to_context_too,
-                                         override_question=args.override_question))
+                                         override_question=args.override_question, override_context=args.override_context))
                  for task, x, bs in zip(args.val_tasks, val_sets, args.val_batch_size)]
 
     aux_iters = []
     if use_curriculum:
         aux_iters = [(name, make_data_loader(x, numericalizer, tok, main_device, train=True,
                                              append_question_to_context_too=args.append_question_to_context_too,
-                                             override_question=args.override_question))
+                                             override_question=args.override_question, override_context=args.override_context))
                      for name, x, tok in zip(args.train_tasks, aux_sets, args.train_batch_values)]
         aux_iters = [(task, iter(aux_iter)) for task, aux_iter in aux_iters]
         

--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -77,7 +77,7 @@ def prepare_data(args, logger):
     for task in args.train_tasks:
         logger.info(f'Loading {task.name}')
         kwargs = {'test': None, 'validation': None}
-        kwargs.update({'subsample': args.subsample, 'skip_cache': args.skip_cache,
+        kwargs.update({'subsample': args.subsample, 'skip_cache': args.skip_cache, 'cache_input_data': args.cache_input_data,
                        'cached_path': os.path.join(args.cache, task.name), 'all_dirs': args.train_languages,
                        'sentence_batching': args.sentence_batching, 'almond_lang_as_question': args.almond_lang_as_question})
         if args.use_curriculum:
@@ -103,7 +103,7 @@ def prepare_data(args, logger):
         # choose best model based on this dev set
         if args.eval_set_name is not None:
             kwargs['validation'] = args.eval_set_name
-        kwargs.update({'subsample': args.subsample, 'skip_cache': args.skip_cache,
+        kwargs.update({'subsample': args.subsample, 'skip_cache': args.skip_cache, 'cache_input_data': args.cache_input_data,
                        'cached_path': os.path.join(args.cache, task.name), 'all_dirs': args.eval_languages,
                         'almond_lang_as_question': args.almond_lang_as_question})
         

--- a/genienlp/util.py
+++ b/genienlp/util.py
@@ -428,7 +428,7 @@ def elapsed_time(log):
 
 
 def make_data_loader(dataset, numericalizer, batch_size, device=None, paired=False, max_pairs=None, train=False,
-                     valid=False, append_question_to_context_too=False, override_question=None):
+                     valid=False, append_question_to_context_too=False, override_question=None, override_context=None):
     
     iterator = Iterator(dataset,
                         batch_size,
@@ -440,7 +440,7 @@ def make_data_loader(dataset, numericalizer, batch_size, device=None, paired=Fal
     collate_function = lambda minibatch: Batch.from_examples(minibatch, numericalizer, device=device,
                                            paired=paired and train, max_pairs=max_pairs, groups=iterator.groups,
                                            append_question_to_context_too=append_question_to_context_too,
-                                                             override_question=override_question)
+                                           override_question=override_question, override_context=override_context)
         
     return torch.utils.data.DataLoader(iterator, batch_size=None, collate_fn=collate_function)
 
@@ -475,7 +475,7 @@ def load_config_json(args):
                     'train_context_embeddings_after', 'train_question_embeddings_after',
                     'pretrain_context', 'pretrain_mlm_probability', 'force_subword_tokenize', 'num_beams',
                     'append_question_to_context_too', 'almond_preprocess_context', 'almond_lang_as_question',
-                    'override_question']
+                    'override_question', 'override_context']
 
         # train and predict scripts have these arguments in common. We use the values from train only if they are not provided in predict
         overwrite = ['val_batch_size', 'num_beams']

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -59,9 +59,9 @@ done
 
 # test almond_multilingual task
 for hparams in \
-      "--encoder_embeddings=bert-base-uncased --decoder_embeddings= --trainable_decoder_embeddings=50 --seq2seq_encoder=Identity --dimension=768" \
-      "--encoder_embeddings=bert-base-uncased --decoder_embeddings= --trainable_decoder_embeddings=50 --seq2seq_encoder=Identity --dimension=768 --sentence_batching --train_batch_size 4 --val_batch_size 4 --use_encoder_loss" \
-      "--encoder_embeddings=bert-base-uncased --decoder_embeddings= --trainable_decoder_embeddings=50 --seq2seq_encoder=Identity --dimension=768 --rnn_zero_state cls --almond_lang_as_question" ;
+      "--encoder_embeddings=bert-base-multilingual-uncased --decoder_embeddings= --trainable_decoder_embeddings=50 --seq2seq_encoder=Identity --dimension=768" \
+      "--encoder_embeddings=bert-base-multilingual-uncased --decoder_embeddings= --trainable_decoder_embeddings=50 --seq2seq_encoder=Identity --dimension=768 --sentence_batching --train_batch_size 4 --val_batch_size 4 --use_encoder_loss" \
+      "--encoder_embeddings=bert-base-multilingual-uncased --decoder_embeddings= --trainable_decoder_embeddings=50 --seq2seq_encoder=Identity --dimension=768 --rnn_zero_state cls --almond_lang_as_question" ;
 
 do
 


### PR DESCRIPTION
Changes:
- New multilingual tasks (QA, contextual NLU for user and agent) inherit from base multilingual almond task.
- Caching data is now done on-demand via --cache_input_data flag. This will free up space on k8s pods.
- Option to override context in all examples. (similar to override question; used for zero-shot cross-domain experiments) 

