### PR TITLE
Wip/speedup

### DIFF
--- a/genienlp/paraphrase/data_utils.py
+++ b/genienlp/paraphrase/data_utils.py
@@ -18,7 +18,7 @@ special_pattern_mapping = [
     SpecialTokenMap('PHONE_NUMBER_([0-9]+)', ['888-8888', '777-8888']),
     SpecialTokenMap('NUMBER_([0-9]+)', ['2', '3'], [['2', 'two'], ['3', 'three']]),
     SpecialTokenMap('PATH_NAME_([0-9]+)', ['my1folder', 'my2folder']),
-    SpecialTokenMap('TIME_([0-9]+)', ['1p.m.', '2p.m.'], [['1 pm', '1pm', '1:00 pm', '1:00pm', '1p.m.', '1 p.m.', '1:00 p.m.', '1:00', 'one o\'clock', 'one'],
+    SpecialTokenMap('TIME_([0-9]+)', ['5p.m.', '2p.m.'], [['5 pm', '5pm', '5:00 pm', '5:00pm', '5p.m.', '5 p.m.', '5:00 p.m.', '5:00', 'five o\'clock', 'five'],
                                                             ['2 pm', '2pm', '2:00 pm', '2:00pm', '2p.m.', '2 p.m.', '2:00 p.m.', '2:00', 'two o\'clock', 'two']]),
     SpecialTokenMap('EMAIL_ADDRESS_([0-9]+)', ['e1@example.com', 'e2@example.com']),
     SpecialTokenMap('URL_([0-9]+)', ['my1site.com', 'my2site.com']),

--- a/genienlp/paraphrase/dataset.py
+++ b/genienlp/paraphrase/dataset.py
@@ -77,7 +77,10 @@ class TextDataset(Dataset):
             output_token_ids = self.tokenizer.encode(output_sequence, add_special_tokens=False) + [self.tokenizer.convert_tokens_to_ids(args.end_special_token)]
         tokenized_text = input_token_ids + output_token_ids
         
-        tokenized_text = tokenized_text[0:self.block_size] # truncate longer sequences
+        # do not use exampels that are too long for the model (for supervised tasks, this is better than truncating examples)
+        if len(tokenized_text) > self.block_size:
+            logger.warning('Skipping example with length %d which was longer than block size (%d)', len(tokenized_text), self.block_size)
+            return
 
         input_ids = self.tokenizer.build_inputs_with_special_tokens(tokenized_text)
         # Remove duplicate end_token for models like BERT and RoBERTa that already add it

--- a/genienlp/paraphrase/run_lm_finetuning.py
+++ b/genienlp/paraphrase/run_lm_finetuning.py
@@ -400,7 +400,7 @@ def parse_argv(parser):
                         help="Optional directory to store the pre-trained models downloaded from s3 (instread of the default one)")
     parser.add_argument("--block_size", default=-1, type=int,
                         help="Optional input sequence length after tokenization."
-                             "The training dataset will be truncated in block of this size for training."
+                             "The training examples that are longerthan this size will not be used for training or evaluation."
                              "Default to the model max input length for single sentence inputs (take into account special tokens).")
     parser.add_argument("--do_train", action='store_true',
                         help="Whether to run training.")

--- a/genienlp/paraphrase/run_lm_finetuning.py
+++ b/genienlp/paraphrase/run_lm_finetuning.py
@@ -45,10 +45,12 @@ from transformers import (WEIGHTS_NAME, AdamW, get_linear_schedule_with_warmup,
 
 from genienlp.util import set_seed
 from genienlp.paraphrase.data_utils import mask_tokens, add_special_tokens, load_and_cache_examples
+from genienlp.paraphrase.dataset import LengthSortedSampler
 from genienlp.paraphrase.model_utils import get_transformer_schedule_with_warmup, _rotate_checkpoints
 
 
 logger = logging.getLogger(__name__)
+
 
 
 MODEL_CLASSES = {
@@ -69,7 +71,10 @@ def train(args, train_dataset, model, tokenizer):
         tb_writer = SummaryWriter(logdir=args.tensorboard_dir)
 
     args.train_batch_size = args.per_gpu_train_batch_size * max(1, args.n_gpu)
-    train_sampler = RandomSampler(train_dataset) if args.local_rank == -1 else DistributedSampler(train_dataset)
+    if args.sort_by_length:
+        train_sampler = LengthSortedSampler(train_dataset, batch_size=args.train_batch_size*args.gradient_accumulation_steps, shuffle=True)
+    else:
+        train_sampler = RandomSampler(train_dataset) if args.local_rank == -1 else DistributedSampler(train_dataset)
     train_dataloader = DataLoader(train_dataset, sampler=train_sampler, batch_size=args.train_batch_size, collate_fn=train_dataset.collate_fn)
 
     if args.max_steps > 0:
@@ -296,7 +301,10 @@ def evaluate(args, model, tokenizer, prefix="", aux=False):
 
     args.eval_batch_size = args.per_gpu_eval_batch_size * max(1, args.n_gpu)
     # Note that DistributedSampler samples randomly
-    eval_sampler = SequentialSampler(eval_dataset)
+    if args.sort_by_length:
+        eval_sampler = LengthSortedSampler(eval_dataset, batch_size=args.eval_batch_size, shuffle=False)
+    else:
+        eval_sampler = SequentialSampler(eval_dataset)
     eval_dataloader = DataLoader(eval_dataset, sampler=eval_sampler, batch_size=args.eval_batch_size, collate_fn=eval_dataset.collate_fn)
 
     # multi-gpu evaluate
@@ -400,8 +408,10 @@ def parse_argv(parser):
                         help="Optional directory to store the pre-trained models downloaded from s3 (instread of the default one)")
     parser.add_argument("--block_size", default=-1, type=int,
                         help="Optional input sequence length after tokenization."
-                             "The training examples that are longerthan this size will not be used for training or evaluation."
+                             "The training examples that are longer than this size (input length + output_length) will not be used for training or evaluation."
                              "Default to the model max input length for single sentence inputs (take into account special tokens).")
+    parser.add_argument('--sort_by_length', action='store_true',
+                        help='Sorts the training set by example length (input length + output_length) to reduce padding and speed up training. Has no effect on accuracy.')
     parser.add_argument("--do_train", action='store_true',
                         help="Whether to run training.")
     parser.add_argument("--do_eval", action='store_true',


### PR DESCRIPTION
This PR makes two changes to speedup paraphrase training (only affects `genienlp train-paraphrase`) and make training GPT-large on a 16GB GPU possible.

1. If `--block_size` is provided, examples longer than that will be thrown away instead of truncated.
2. Passing `--sort_by_length` will group training examples with similar lengths together. This reduces the need for padding tokens during training and evaluation. Note that the each minibatch has examples of similar length, but the order of minibatches is still random. With batch size of 2, this has no effect on training speed; however, with larger batch sizes, the benefits are significant.
For instance, --sort_by_length gives a ~2.5x speedup for batch size of 32.
Surprisingly, this has a positive effect in terms of accuracy/BLEU score on BART,  GPT2-medium, GPT2-small and distil-GPT2, but no effect on GPT2-large.