### PR TITLE
Wip/transformers bump 4.0.0 rebased

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,7 @@ pyrouge = ">=0.1.3"
 sacrebleu = "~=1.0"
 tensorboardX = "==2.0.*"
 requests = "~=2.22"
-transformers = "==3.5.1"
+transformers = "==4.0.0"
 radam = {git = "https://github.com/LiyuanLucasLiu/RAdam"}
 sentencepiece = "==0.1.91"
 mosestokenizer = '~=1.1'

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a61731c23d602fd16370c40337080c1aa85dc03e4898825859db5b78ddc3f5df"
+            "sha256": "bb6e1c3fafcad025a82c3ac259a4c510ab1cb1df9275dfcd74238a9a0d168a01"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd",
-                "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2020.11.8"
+            "version": "==2020.12.5"
         },
         "chardet": {
             "hashes": [
@@ -215,32 +215,32 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:09e0503758ad61afe81c9069505f8cb8c1e36ea8cc1e6826a95823ef5b327daf",
-                "sha256:0a11a6290ef3667575cbd4785a1b62d658c25a2fd70a5adedba32e156a8f1773",
-                "sha256:0d9a38a59242a2f6298fff45d09768b78b6eb0c52af5919ea9e45965d7ba56d9",
-                "sha256:112c5ba0f9ea0f60b2cc38c25f87ca1d5ca10f71efbee8e0f1bee9cf584ed5d5",
-                "sha256:185cf8c8f38b169dbf7001e1a88c511f653fbb9dfa3e048f5e19c38049e991dc",
-                "sha256:3aa8e10768c730cc1b610aca688f588831fa70b65a26cb549fbb9f35049a05e0",
-                "sha256:41746d520f2b50409dffdba29a15c42caa7babae15616bcf80800d8cfcae3d3e",
-                "sha256:43cea38cbcadb900829858884f49745eb1f42f92609d368cabcc674b03e90efc",
-                "sha256:5378f58172bd63d8c16dd5d008d7dcdd55bf803fcdbe7da2dcb65dbbf322f05b",
-                "sha256:54404abb1cd3f89d01f1fb5350607815326790efb4789be60508f458cdd5ccbf",
-                "sha256:5dac3aeaac5feb1016e94bde851eb2012d1733a222b8afa788202b836c97dad5",
-                "sha256:5fdb2a61e477ce58d3f1fdf2470ee142d9f0dde4969032edaf0b8f1a9dafeaa2",
-                "sha256:6613c7815ee0b20222178ad32ec144061cb07e6a746970c9160af1ebe3ad43b4",
-                "sha256:6d2b5b58e7df46b2c010ec78d7fb9ab20abf1d306d0614d3432e7478993fbdb0",
-                "sha256:8a5d7e57b9df2c0a9a202840b2881bb1f7a648eba12dd2d919ac07a33a36a97f",
-                "sha256:8b4c2055ebd6e497e5ecc06efa5b8aa76f59d15233356eb10dad22a03b757805",
-                "sha256:a15653480e5b92ee376f8458197a58cca89a6e95d12cccb4c2d933df5cecc63f",
-                "sha256:a7d2547b601ecc9a53fd41561de49a43d2231728ad65c7713d6b616cd02ddbed",
-                "sha256:a979d0404b135c63954dea79e6246c45dd45371a88631cdbb4877d844e6de3b6",
-                "sha256:b1f8111635700de7ac350b639e7e452b06fc541a328cf6193cf8fc638804bab8",
-                "sha256:c5a3597880a7a29a31ebd39b73b2c824316ae63a05c3c8a5ce2aea3fc68afe35",
-                "sha256:c681e8fcc47a767bf868341d8f0d76923733cbdcabd6ec3a3560695c69f14a1e",
-                "sha256:cf135a08f306ebbcfea6da8bf775217613917be23e5074c69215b91e180caab4",
-                "sha256:e2b8557fe6d0a18db4d61c028c6af61bfed44ef90e419ed6fadbdc079eba141e"
+                "sha256:0a643bae4283a37732ddfcecab3f62dd082996021b980f580903f4e8e01b3c5b",
+                "sha256:0de3ddb414d30798cbf56e642d82cac30a80223ad6fe484d66c0ce01a84d6f2f",
+                "sha256:19a2148a1d02791352e9fa637899a78e371a3516ac6da5c4edc718f60cbae648",
+                "sha256:21b5a2b033380adbdd36b3116faaf9a4663e375325831dac1b519a44f9e439bb",
+                "sha256:24c7f8d4aee71bfa6401faeba367dd654f696a77151a8a28bc2013f7ced4af98",
+                "sha256:26fa92d3ac743a149a31b21d6f4337b0594b6302ea5575b37af9ca9611e8981a",
+                "sha256:2860a97cbb25444ffc0088b457da0a79dc79f9c601238a3e0644312fcc14bf11",
+                "sha256:2b1c6cd28a0dfda75c7b5957363333f01d370936e4c6276b7b8e696dd500582a",
+                "sha256:2c2f7c670ea4e60318e4b7e474d56447cf0c7d83b3c2a5405a0dbb2600b9c48e",
+                "sha256:3be7a7a0ca71a2640e81d9276f526bca63505850add10206d0da2e8a0a325dae",
+                "sha256:4c62e94d5d49db116bef1bd5c2486723a292d79409fc9abd51adf9e05329101d",
+                "sha256:5008374ebb990dad9ed48b0f5d0038124c73748f5384cc8c46904dace27082d9",
+                "sha256:5447ea7af4005b0daf695a316a423b96374c9c73ffbd4533209c5ddc369e644b",
+                "sha256:573fba5b05bf2c69271a32e52399c8de599e4a15ab7cec47d3b9c904125ab788",
+                "sha256:5a780260afc88268a9d3ac3511d8f494fdcf637eece62fb9eb656a63d53eb7ca",
+                "sha256:70865f96bb38fec46f7ebd66d4b5cfd0aa6b842073f298d621385ae3898d28b5",
+                "sha256:731568be71fba1e13cae212c362f3d2ca8932e83cb1b85e3f1b4dd77d019254a",
+                "sha256:b61080750d19a0122469ab59b087380721d6b72a4e7d962e4d7e63e0c4504814",
+                "sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d",
+                "sha256:c16d59c15d946111d2716856dd5479221c9e4f2f5c7bc2d617f39d870031e086",
+                "sha256:c61c043aafb69329d0f961b19faa30b1dab709dd34c9388143fc55680059e55a",
+                "sha256:c94ff2780a1fd89f190390130d6d36173ca59fcfb3fe0ff596f9a56518191ccb",
+                "sha256:edda9bacc3843dfbeebaf7a701763e68e741b08fccb889c003b0a52f0ee95782",
+                "sha256:f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b"
             ],
-            "version": "==1.1.4"
+            "version": "==1.1.5"
         },
         "pillow": {
             "hashes": [
@@ -499,25 +499,49 @@
         },
         "tokenizers": {
             "hashes": [
-                "sha256:0f30e6a9ea56cc8d999b17142f121ddb24b005b9fce936e7df47cdff1f55edcc",
-                "sha256:219dafb24d26a10bd4162372901ac886254e1c6bf6510dde85df282469231eaf",
-                "sha256:27ec3543e6e5701586804b1536cf687d44f8167871bd84ab01e5700cbfa969ec",
-                "sha256:2d875e019e39bce56c35a126ef4338345d97bf5e53730c68d0f7128a05c3d6c0",
-                "sha256:3100ed9051558a3b2a9c2b7dda6880328a7c4c0736be72d279b0029339d55789",
-                "sha256:3f199b1042d56837b5764c212874510f8eab7702d7486fdb626432465717e4f7",
-                "sha256:424d8ab61b0b0afadf4d88beded036cb801e3a4ddba6804621568cefd5ddb317",
-                "sha256:5b35be31ca999f9fb4732d947fa629104a29af3633e73cf8311cb69948f80165",
-                "sha256:a8c197a0d8f8b91cc220315e1617b942d992ae70bade504838b70e49bf5e4454",
-                "sha256:b9c5c304bfdba4e703f8828bf4c57d3d65b3c77d2732f5ec81044abe8287f2de",
-                "sha256:bacaeb3621055aba9b5158a21dc8b5d80f65724ff47f414f9d06f1e087668d61",
-                "sha256:be639a8933206dfd6e1cab26683ce020c03c6a3757d4a1dd5c8854d2bbed09ae",
-                "sha256:e2d709d028fe87dc305c767acca2da0425029fa0ae2135a2139ead7de62bc276",
-                "sha256:e76f84123695ccfaef734912369edbcb8ed71723196987ffd086e07d00c9d73a",
-                "sha256:ea1db6a8ebdf29f0487212c35357574c70f72c7c311406603fabeaa44cc94a12",
-                "sha256:ef6208dfdd2536566d0eee06a03da1a74b9c9246ef5c4a213d5afd00f51d0976",
-                "sha256:f71161ed25ab649e9291139f7ce6a28cd520de5de9246e2907a19a6f329b9105"
+                "sha256:06e1a1c50c7600d8162d8f0eeed460ad9e9234ffee7d5c7bcd1308024d781647",
+                "sha256:082de5272363aee13f36641065a3dd2d78f5b51486e3ab7d6d34138905a46303",
+                "sha256:1313d63ce286c6c9812a51ea39ae84cf1b8f2887c8ce8cc813459fdfbf526c9b",
+                "sha256:15440ba1db7c7b3eb7b5881b276555e25420ce14639926585837b7b60ddb55a8",
+                "sha256:1764a705be63fb61abcaa96637399f124528f9a01925c88efb438aefe315b61b",
+                "sha256:2479ef9a30fe8a961cb49c8bf6a5c5e2ce8e1b87849374c9756f41cf06189bdf",
+                "sha256:2dd1156815cf2ca2a0942c8efc72e0725b6cd4640a61e026c72bf5a330f4383a",
+                "sha256:31184c4691aed1e84088d7a18c1000bbc59f7bedeec95774ec4027129ea16272",
+                "sha256:3cf5b470b2e06aadee22771740d87a706216385f881308c70cb317476ec40904",
+                "sha256:3ea3038008f1f74c8a1e1e2e73728690eed2d7fa4db0a51bcea391e644672426",
+                "sha256:3ea6d65a32c8b3236553e489573f42855af484d24bf96ab32a5d6d1a2c4b0ed0",
+                "sha256:427257e78b71e9310d0c035df9b054525d1da91cc46efbae95fee2d523b88eb9",
+                "sha256:4a5ddd6689e18b6c5398b97134e79e948e1bbe7664f6962aa63f50fb05cae091",
+                "sha256:4fd1a765af0a7aff7dab58d7fcd63a2e4a860e829b931bdfd59e2c56ba1769b9",
+                "sha256:53395c4423e8309b208f1e973337c08a3cb68af5eb9dee8d8618428fd4579803",
+                "sha256:535cf3edfd0df2c1887ea388691dd8f614331f47b41cb40c0901a2ce070ff7e0",
+                "sha256:543dcb31b8534cf3ad66817f925f50f4ccd182ed1433fcd07adaed5d389f682b",
+                "sha256:58e1904c3e75e37be379ee4b29b21b05189d54bfab0260b334cff6e5a44a4f45",
+                "sha256:768f36e743604f567f4e4817a76738ed1bcdaecfef5ae8c74bdf2277a7a1902d",
+                "sha256:800917d7085245db0b55f88b2a12bd0ba4eb5966e8b88bd9f21aa46aadfa8204",
+                "sha256:807f321731a3466b9e0230cbc8e6d9c5581d5ac6536d96360b5fe1ec457d837f",
+                "sha256:89f816e5aa61c464e9d82025f2c4f1f66cd92f648ab9194a154ba2b0e180dc70",
+                "sha256:8d8ca7daa2f2274ec9327961ac828c20fcadd76e88d07f611742f240a6c73abe",
+                "sha256:96879e21be25b63fb99fa7d65b50b05c2a0333f104ca003917df7433d6eb073e",
+                "sha256:9de00f951fa8c1cf5c54a5a813447c9bf810759822de6ba6cfa42d7f503ff799",
+                "sha256:9f79b57a4d6a1aa8379a931e8ee54cb155cc3f5f1ba5172bcdea504dbd4cb746",
+                "sha256:a03c101d8058c851a7647cc74c68d4db511d7a3db8a73f7ec715e4fe14281ed7",
+                "sha256:a3180c8a1cb77eca8fe9c291e0f197aee202c93ffdea4f96d06ca154f319980c",
+                "sha256:abdbd169738c33e2e643e7701230f43c2f4e6e03d49283d4250f19159f6a6c71",
+                "sha256:ac4c0a2f052a83146c6475dc22f9eb740d352b29779ac6036459f00d897025b8",
+                "sha256:b49f17c2ac2bf88875a74d63e8070fd5a69e8c3b2874dee47649826b603a3af1",
+                "sha256:b57fc7f2003f1f7b873dcffd5d0ee7c71f01709c54c36f4d191e4a7911d49565",
+                "sha256:bce664d24c744387760beab14cc7bd4e405bbef93c333ba3ca4a93347949c3ba",
+                "sha256:bd46747f5c7d6e1721234d5ec1c0038bcfe0050c147c92171c3ef5b36d6fb2a9",
+                "sha256:c496748853c0300b8b7be916e130f0de8224575ee72e8889405477f120bfe575",
+                "sha256:c60b8ba2d8a948bb40c39223a4b2553c7c1df9f732b0077722b91df5d63c5e37",
+                "sha256:c83f7a26d6f0c765906440c7f2b726cbd18e5c7a63e0364095600c91e2905cc4",
+                "sha256:d2824dedd9f26e3757159d99c743b287ebf78775ccf4a36a3e0ec7058ee66303",
+                "sha256:d518ef8323690cd4d51979ff2f44edbac5862db8c8af125e815e41cf4517c638",
+                "sha256:da361a88b21cd141441fb139d1ee05c815103d49d10b49bfb4218a240d0d5a84",
+                "sha256:f3351eef9187ba7b9ceb04ff74fcda535f26c4146fe40155c6ed6087302944fd"
             ],
-            "version": "==0.9.3"
+            "version": "==0.9.4"
         },
         "toolwrapper": {
             "hashes": [
@@ -530,7 +554,10 @@
                 "sha256:11054f26eee5c3114d217201dba5b3a35f1745d11133c123c077c5981bc95997",
                 "sha256:1520c48430dea38e5845b7b3defc9054edad45f1f245808aa268ade840bb2c2a",
                 "sha256:6b0c9b56cb56afe3ecbac79351d21c6f7172dffc7b7daa8c365f660541baf1a5",
+                "sha256:83538fd7920bd02c8b6403ebe4ecee3e0641fe7bb6a18efc4585d2e1375ad1de",
                 "sha256:89cb8774243750bd3fd2b3b3d09bab6e3be68b1785ad48b8411f1eb4fc7acdba",
+                "sha256:a29a7aab6fa161259219c8aaa88b25abbf214ec098a002c4499660c23e0f6c33",
+                "sha256:b609b30b09627409612461b247531cf50894256e8b026105f1bc3858d67c2fa7",
                 "sha256:b8000e39600e101b2f19dbbab75de663a3b78e3979c3e1720b7136aae1c35ce2",
                 "sha256:e8cc3b2c3937b7ae036a3b447a189af049bfc006bca054fc1d8ae78766ca3105"
             ],
@@ -539,19 +566,19 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:5c0d04e06ccc0da1bd3fa5ae4550effcce42fcad947b4a6cafa77bdc9b09ff22",
-                "sha256:9e7b8ab0ecbdbf0595adadd5f0ebbb9e69010e0bd48bbb0c15e550bf2a5292df"
+                "sha256:38b658a3e4ecf9b4f6f8ff75ca16221ae3378b2e175d846b6b33ea3a20852cf5",
+                "sha256:d4f413aecb61c9779888c64ddf0c62910ad56dcbe857d8922bb505d4dbff0df1"
             ],
             "index": "pypi",
-            "version": "==4.54.0"
+            "version": "==4.54.1"
         },
         "transformers": {
             "hashes": [
-                "sha256:0d637c6cecc13b12f33f9e79bf5757c85f433c851e3ae7845ff20b6c49f41441",
-                "sha256:cefb06c8892e0ce2de1bfc782d2c49af020960ebada8340317306ff606190341"
+                "sha256:5b8618e8fe34de078ccb214f2f6c27bcb6753980aaeb9271ce07169a91b74afc",
+                "sha256:bc71a06dbcd98807d7fe512938dd4ffc7801275d5c54e1c73434ff5a9f5d2f46"
             ],
             "index": "pypi",
-            "version": "==3.5.1"
+            "version": "==4.0.0"
         },
         "typing-extensions": {
             "hashes": [

--- a/genienlp/arguments.py
+++ b/genienlp/arguments.py
@@ -39,6 +39,10 @@ from .util import have_multilingual
 from .paraphrase.transformers_utils import BART_PRETRAINED_CONFIG_ARCHIVE_MAP
 BART_MODEL_LIST = list(BART_PRETRAINED_CONFIG_ARCHIVE_MAP.keys())
 
+from transformers.models.bart.modeling_bart import BART_PRETRAINED_MODEL_ARCHIVE_LIST
+BART_MODEL_LIST = BART_PRETRAINED_MODEL_ARCHIVE_LIST + ['sshleifer/bart-tiny-random']
+MT5_MODEL_LIST = ['google/mt5-' + v for v in ['small', 'base', 'large', 'xl', 'xxl']]
+
 logger = logging.getLogger(__name__)
 
 
@@ -141,10 +145,11 @@ def parse_argv(parser):
 
     parser.add_argument("--almond_has_multiple_programs", action='store_true', help='Indicate if almond dataset has multiple programs for each sentence')
 
-    parser.add_argument('--model', type=str, choices=['Seq2Seq', 'Bart'], default='Seq2Seq', help='which model to import')
+    parser.add_argument('--model', type=str, choices=['Transformer2LSTMModel', 'Bart', 'MT5'], default='Transformer2LSTMModel', help='which model to import')
     parser.add_argument('--seq2seq_encoder', type=str, choices=['MQANEncoder', 'BiLSTM', 'Identity', 'Coattention'],
                         default='MQANEncoder', help='which encoder to use for the Seq2Seq model')
-    parser.add_argument('--seq2seq_decoder', type=str, choices=['MQANDecoder'] + BART_MODEL_LIST, default='MQANDecoder',
+
+    parser.add_argument('--seq2seq_decoder', type=str, choices=['MQANDecoder'] + BART_MODEL_LIST + MT5_MODEL_LIST, default='MQANDecoder',
                         help='which decoder to use for the Seq2Seq model')
     parser.add_argument('--dimension', default=200, type=int, help='output dimensions for all layers')
     parser.add_argument('--rnn_dimension', default=None, type=int, help='output dimensions for RNN layers')

--- a/genienlp/arguments.py
+++ b/genienlp/arguments.py
@@ -141,7 +141,7 @@ def parse_argv(parser):
 
     parser.add_argument("--almond_has_multiple_programs", action='store_true', help='Indicate if almond dataset has multiple programs for each sentence')
 
-    parser.add_argument('--model', type=str, choices=['Transformer2LSTM', 'Bart', 'MT5', 'MBart'], default='Transformer2LSTM', help='which model to import')
+    parser.add_argument('--model', type=str, choices=['Seq2Seq', 'Bart', 'MT5', 'MBart'], default='Seq2Seq', help='which model to import')
     parser.add_argument('--seq2seq_encoder', type=str, choices=['MQANEncoder', 'BiLSTM', 'Identity', 'Coattention'],
                         default='MQANEncoder', help='which encoder to use for the Seq2Seq model')
     parser.add_argument('--seq2seq_decoder', type=str, choices=['MQANDecoder'] + BART_MODEL_LIST + MBART_MODEL_LIST + MT5_MODEL_LIST, default='MQANDecoder',

--- a/genienlp/arguments.py
+++ b/genienlp/arguments.py
@@ -36,12 +36,8 @@ import subprocess
 
 from .tasks.registry import get_tasks
 from .util import have_multilingual
-from .paraphrase.transformers_utils import BART_PRETRAINED_CONFIG_ARCHIVE_MAP
-BART_MODEL_LIST = list(BART_PRETRAINED_CONFIG_ARCHIVE_MAP.keys())
+from .paraphrase.transformers_utils import BART_MODEL_LIST, MBART_MODEL_LIST, MT5_MODEL_LIST
 
-from transformers.models.bart.modeling_bart import BART_PRETRAINED_MODEL_ARCHIVE_LIST
-BART_MODEL_LIST = BART_PRETRAINED_MODEL_ARCHIVE_LIST + ['sshleifer/bart-tiny-random']
-MT5_MODEL_LIST = ['google/mt5-' + v for v in ['small', 'base', 'large', 'xl', 'xxl']]
 
 logger = logging.getLogger(__name__)
 
@@ -145,11 +141,10 @@ def parse_argv(parser):
 
     parser.add_argument("--almond_has_multiple_programs", action='store_true', help='Indicate if almond dataset has multiple programs for each sentence')
 
-    parser.add_argument('--model', type=str, choices=['Transformer2LSTMModel', 'Bart', 'MT5'], default='Transformer2LSTMModel', help='which model to import')
+    parser.add_argument('--model', type=str, choices=['Transformer2LSTMModel', 'Bart', 'MT5', 'MBart'], default='Transformer2LSTMModel', help='which model to import')
     parser.add_argument('--seq2seq_encoder', type=str, choices=['MQANEncoder', 'BiLSTM', 'Identity', 'Coattention'],
                         default='MQANEncoder', help='which encoder to use for the Seq2Seq model')
-
-    parser.add_argument('--seq2seq_decoder', type=str, choices=['MQANDecoder'] + BART_MODEL_LIST + MT5_MODEL_LIST, default='MQANDecoder',
+    parser.add_argument('--seq2seq_decoder', type=str, choices=['MQANDecoder'] + BART_MODEL_LIST + MBART_MODEL_LIST + MT5_MODEL_LIST, default='MQANDecoder',
                         help='which decoder to use for the Seq2Seq model')
     parser.add_argument('--dimension', default=200, type=int, help='output dimensions for all layers')
     parser.add_argument('--rnn_dimension', default=None, type=int, help='output dimensions for RNN layers')

--- a/genienlp/arguments.py
+++ b/genienlp/arguments.py
@@ -141,7 +141,7 @@ def parse_argv(parser):
 
     parser.add_argument("--almond_has_multiple_programs", action='store_true', help='Indicate if almond dataset has multiple programs for each sentence')
 
-    parser.add_argument('--model', type=str, choices=['Transformer2LSTMModel', 'Bart', 'MT5', 'MBart'], default='Transformer2LSTMModel', help='which model to import')
+    parser.add_argument('--model', type=str, choices=['Transformer2LSTM', 'Bart', 'MT5', 'MBart'], default='Transformer2LSTM', help='which model to import')
     parser.add_argument('--seq2seq_encoder', type=str, choices=['MQANEncoder', 'BiLSTM', 'Identity', 'Coattention'],
                         default='MQANEncoder', help='which encoder to use for the Seq2Seq model')
     parser.add_argument('--seq2seq_decoder', type=str, choices=['MQANDecoder'] + BART_MODEL_LIST + MBART_MODEL_LIST + MT5_MODEL_LIST, default='MQANDecoder',

--- a/genienlp/data_utils/embeddings.py
+++ b/genienlp/data_utils/embeddings.py
@@ -42,6 +42,8 @@ from . import word_vectors
 from .almond_embeddings import AlmondEmbeddings
 from .pretrained_lstm_lm import PretrainedLTSMLM
 
+from transformers.modeling_outputs import BaseModelOutputWithPoolingAndCrossAttentions as EmbeddingOutput
+
 logger = logging.getLogger(__name__)
 
 EMBEDDING_NAME_TO_NUMERICALIZER_MAP = dict()
@@ -50,8 +52,8 @@ EMBEDDING_NAME_TO_NUMERICALIZER_MAP.update({embedding: XLMRobertaNumericalizer f
 
 
 class EmbeddingOutput(NamedTuple):
-    all_layers: List[torch.Tensor]
-    last_layer: torch.Tensor
+    hidden_states: List[torch.Tensor]
+    last_hidden_state: torch.Tensor
 
 class WordVectorEmbedding(torch.nn.Module):
     def __init__(self, vec_collection):
@@ -88,8 +90,8 @@ class WordVectorEmbedding(torch.nn.Module):
             self.embedding[0].weight.data = torch.cat([self.embedding[0].weight.data.cpu()] + new_vectors, dim=0)
 
     def forward(self, input: torch.Tensor, padding=None):
-        last_layer = self.embedding[0](input.cpu()).to(input.device)
-        return EmbeddingOutput(all_layers=[last_layer], last_layer=last_layer)
+        last_hidden_state = self.embedding[0](input.cpu()).to(input.device)
+        return EmbeddingOutput(hidden_states=[last_hidden_state], last_hidden_state=last_hidden_state)
 
     def to(self, *args, **kwargs):
         # ignore attempts to move the word embedding, which should stay on CPU
@@ -115,9 +117,10 @@ class TransformerEmbedding(torch.nn.Module):
         self.model.resize_token_embeddings(len(vocab))
 
     def forward(self, input: torch.Tensor, padding=None):
-        last_hidden_state, _pooled, hidden_states = self.model(input, attention_mask=(~padding).to(dtype=torch.float))
-
-        return EmbeddingOutput(all_layers=hidden_states, last_layer=last_hidden_state)
+        return self.model(input, attention_mask=(~padding).to(dtype=torch.float))
+        # last_hidden_state, _pooled, hidden_states =
+        #
+        # return EmbeddingOutput(hidden_states=hidden_states, last_hidden_state=last_hidden_state)
 
 class PretrainedLMEmbedding(torch.nn.Module):
     def __init__(self, model_name, cachedir):
@@ -157,7 +160,7 @@ class PretrainedLMEmbedding(torch.nn.Module):
     def forward(self, input: torch.Tensor, padding=None):
         pretrained_indices = torch.gather(self.vocab_to_pretrained, dim=0, index=input)
         rnn_output = self.model(pretrained_indices)
-        return EmbeddingOutput(all_layers=[rnn_output], last_layer=rnn_output)
+        return EmbeddingOutput(hidden_states=[rnn_output], last_hidden_state=rnn_output)
 
 def _name_to_vector(emb_name, cachedir):
     if emb_name == 'glove':

--- a/genienlp/data_utils/numericalizer/transformer.py
+++ b/genienlp/data_utils/numericalizer/transformer.py
@@ -396,7 +396,10 @@ class Seq2SeqNumericalizer(TransformerNumericalizer):
     
     def __init__(self, pretrained_tokenizer=None, config=None, max_generative_vocab=None, cache=None, fix_length=None):
         super().__init__(pretrained_tokenizer, config, max_generative_vocab, cache, fix_length)
-        self.load(pretrained_tokenizer, config)
+        
+    @property
+    def pad_id(self):
+        return self._tokenizer.pad_token_id
     
     def load(self, save_dir, config=None):
         raise NotImplementedError
@@ -441,12 +444,20 @@ class Seq2SeqNumericalizer(TransformerNumericalizer):
 
 class BartNumericalizer(Seq2SeqNumericalizer):
     
+    def __init__(self, pretrained_tokenizer=None, config=None, max_generative_vocab=None, cache=None, fix_length=None):
+        super().__init__(pretrained_tokenizer, config, max_generative_vocab, cache, fix_length)
+        self.load(pretrained_tokenizer, config)
+        
     def load(self, save_dir, config=None):
         self._tokenizer = BartTokenizer.from_pretrained(save_dir)
         self.decoder_vocab = DecoderVocabulary(self._tokenizer.decoder.values(), None,
                                                pad_token=self._tokenizer.pad_token, eos_token=self._tokenizer.eos_token)
 
 class MBartNumericalizer(Seq2SeqNumericalizer):
+    
+    def __init__(self, pretrained_tokenizer=None, config=None, max_generative_vocab=None, cache=None, fix_length=None):
+        super().__init__(pretrained_tokenizer, config, max_generative_vocab, cache, fix_length)
+        self.load(pretrained_tokenizer, config)
     
     def load(self, save_dir, config=None):
         self._tokenizer = MBartTokenizer.from_pretrained(save_dir, config=config)
@@ -457,8 +468,12 @@ class MBartNumericalizer(Seq2SeqNumericalizer):
 
 class MT5Numericalizer(Seq2SeqNumericalizer):
     
+    def __init__(self, pretrained_tokenizer=None, config=None, max_generative_vocab=None, cache=None, fix_length=None):
+        super().__init__(pretrained_tokenizer, config, max_generative_vocab, cache, fix_length)
+        self.load(pretrained_tokenizer, config)
+        
     def load(self, save_dir, config=None):
-        self._tokenizer = T5Tokenizer.from_pretrained(pretrained_tokenizer, config=config)
+        self._tokenizer = T5Tokenizer.from_pretrained(save_dir, config=config)
         vocabs = [self._tokenizer.sp_model.id_to_piece(i) for i in range(self._tokenizer.sp_model.get_piece_size())]
         self.decoder_vocab = DecoderVocabulary(vocabs, None, pad_token=self._tokenizer.pad_token,
                                                eos_token=self._tokenizer.eos_token)

--- a/genienlp/data_utils/numericalizer/transformer.py
+++ b/genienlp/data_utils/numericalizer/transformer.py
@@ -34,9 +34,10 @@ from torch.nn.utils.rnn import pad_sequence
 
 from .decoder_vocab import DecoderVocabulary
 from .masked_tokenizer import MaskedBertTokenizer, MaskedXLMRobertaTokenizer
-from transformers import BartTokenizer
+from transformers import BartTokenizer, T5Tokenizer
 from .sequential_field import SequentialField
 from transformers.file_utils import SPIECE_UNDERLINE
+
 
 class TransformerNumericalizer(object):
     """
@@ -152,6 +153,7 @@ class TransformerNumericalizer(object):
 
     def reverse(self, batch, detokenize, field_name=None):
         raise NotImplementedError()
+
 
 class XLMRobertaNumericalizer(TransformerNumericalizer):
 
@@ -280,6 +282,7 @@ class XLMRobertaNumericalizer(TransformerNumericalizer):
 
         return [reverse_one(tensor, field_name) for tensor in batch]
 
+
 class BertNumericalizer(TransformerNumericalizer):
     """
     Numericalizer that uses BertTokenizer from huggingface's transformers library.
@@ -395,12 +398,13 @@ class BartNumericalizer(TransformerNumericalizer):
     def __init__(self, pretrained_tokenizer=None, config=None, max_generative_vocab=None, cache=None, fix_length=None):
         super().__init__(pretrained_tokenizer, config, max_generative_vocab, cache, fix_length)
         self._tokenizer = BartTokenizer.from_pretrained(pretrained_tokenizer, config=config)
-        self.decoder_vocab = DecoderVocabulary(self._tokenizer.decoder.values(), None, pad_token=self._tokenizer.pad_token, eos_token=self._tokenizer.eos_token)
-
+        self.decoder_vocab = DecoderVocabulary(self._tokenizer.decoder.values(), None,
+                                               pad_token=self._tokenizer.pad_token, eos_token=self._tokenizer.eos_token)
 
     def load(self, save_dir):
         self._tokenizer = BartTokenizer.from_pretrained(save_dir)
-        self.decoder_vocab = DecoderVocabulary(self._tokenizer.decoder.values(), None, pad_token=self._tokenizer.pad_token, eos_token=self._tokenizer.eos_token)
+        self.decoder_vocab = DecoderVocabulary(self._tokenizer.decoder.values(), None,
+                                               pad_token=self._tokenizer.pad_token, eos_token=self._tokenizer.eos_token)
 
     @property
     def pad_id(self):
@@ -442,4 +446,55 @@ class BartNumericalizer(TransformerNumericalizer):
 
     def decode(self, tensor):
         return self._tokenizer.convert_ids_to_tokens(tensor)
+
+
+class MT5Numericalizer(TransformerNumericalizer):
+    
+    def __init__(self, pretrained_tokenizer=None, config=None, max_generative_vocab=None, cache=None, fix_length=None):
+        super().__init__(pretrained_tokenizer, config, max_generative_vocab, cache, fix_length)
+        self._tokenizer = T5Tokenizer.from_pretrained(pretrained_tokenizer, config=config)
         
+        vocabs = [self._tokenizer.sp_model.id_to_piece(i) for i in range(self._tokenizer.sp_model.get_piece_size())]
+        self.decoder_vocab = DecoderVocabulary(vocabs, None, pad_token=self._tokenizer.pad_token,
+                                               eos_token=self._tokenizer.eos_token)
+    
+    def load(self, save_dir):
+        self._tokenizer = T5Tokenizer.from_pretrained(save_dir)
+        self.decoder_vocab = DecoderVocabulary(self._tokenizer.decoder.values(), None,
+                                               pad_token=self._tokenizer.pad_token, eos_token=self._tokenizer.eos_token)
+    
+    def save(self, save_dir):
+        self._tokenizer.save_pretrained(save_dir)
+    
+    def build_vocab(self, vocab_fields, vocab_sets):
+        raise NotImplementedError
+    
+    def encode_single(self, minibatch, decoder_vocab, device=None, max_length=-1):
+        """
+		minibatch: this method ignores the `mask` component of minibatch
+		"""
+        assert isinstance(minibatch, list)
+        batch_tokens = []
+        for tokens, mask in minibatch:
+            if len(tokens) == 0:
+                batch_tokens.append(' ')
+            else:
+                batch_tokens.append(' '.join(tokens))
+        
+        encoded_batch = self._tokenizer.batch_encode_plus(batch_tokens, add_special_tokens=True, padding=False, return_attention_mask=True)
+        length = torch.sum(torch.tensor(encoded_batch['attention_mask'], dtype=torch.int32, device=device), dim=1)
+        numerical = torch.tensor(encoded_batch['input_ids'], dtype=torch.int64, device=device)
+        
+        decoder_numerical = numerical
+        return SequentialField(length=length, value=numerical, limited=decoder_numerical)
+    
+    def encode_pair(self, minibatch, decoder_vocab, device=None):
+        # TODO
+        raise NotImplementedError
+    
+    def reverse(self, batch, detokenize, field_name=None):
+        _reversed = self._tokenizer.batch_decode(batch, skip_special_tokens=True)
+        return _reversed
+    
+    def decode(self, tensor):
+        return self._tokenizer.convert_ids_to_tokens(tensor)

--- a/genienlp/data_utils/numericalizer/transformer.py
+++ b/genienlp/data_utils/numericalizer/transformer.py
@@ -34,7 +34,7 @@ from torch.nn.utils.rnn import pad_sequence
 
 from .decoder_vocab import DecoderVocabulary
 from .masked_tokenizer import MaskedBertTokenizer, MaskedXLMRobertaTokenizer
-from transformers import BartTokenizer, T5Tokenizer
+from transformers import BartTokenizer, MBartTokenizer, T5Tokenizer
 from .sequential_field import SequentialField
 from transformers.file_utils import SPIECE_UNDERLINE
 
@@ -392,24 +392,15 @@ class BertNumericalizer(TransformerNumericalizer):
         return [reverse_one(tensor) for tensor in batch]
 
 
-# TODO
-class BartNumericalizer(TransformerNumericalizer):
-
+class Seq2SeqNumericalizer(TransformerNumericalizer):
+    
     def __init__(self, pretrained_tokenizer=None, config=None, max_generative_vocab=None, cache=None, fix_length=None):
         super().__init__(pretrained_tokenizer, config, max_generative_vocab, cache, fix_length)
-        self._tokenizer = BartTokenizer.from_pretrained(pretrained_tokenizer, config=config)
-        self.decoder_vocab = DecoderVocabulary(self._tokenizer.decoder.values(), None,
-                                               pad_token=self._tokenizer.pad_token, eos_token=self._tokenizer.eos_token)
-
-    def load(self, save_dir):
-        self._tokenizer = BartTokenizer.from_pretrained(save_dir)
-        self.decoder_vocab = DecoderVocabulary(self._tokenizer.decoder.values(), None,
-                                               pad_token=self._tokenizer.pad_token, eos_token=self._tokenizer.eos_token)
-
-    @property
-    def pad_id(self):
-        return self._tokenizer.pad_token_id
-
+        self.load(pretrained_tokenizer, config)
+    
+    def load(self, save_dir, config=None):
+        raise NotImplementedError
+    
     def save(self, save_dir):
         self._tokenizer.save_pretrained(save_dir)
 
@@ -448,53 +439,26 @@ class BartNumericalizer(TransformerNumericalizer):
         return self._tokenizer.convert_ids_to_tokens(tensor)
 
 
-class MT5Numericalizer(TransformerNumericalizer):
+class BartNumericalizer(Seq2SeqNumericalizer):
     
-    def __init__(self, pretrained_tokenizer=None, config=None, max_generative_vocab=None, cache=None, fix_length=None):
-        super().__init__(pretrained_tokenizer, config, max_generative_vocab, cache, fix_length)
+    def load(self, save_dir, config=None):
+        self._tokenizer = BartTokenizer.from_pretrained(save_dir)
+        self.decoder_vocab = DecoderVocabulary(self._tokenizer.decoder.values(), None,
+                                               pad_token=self._tokenizer.pad_token, eos_token=self._tokenizer.eos_token)
+
+class MBartNumericalizer(Seq2SeqNumericalizer):
+    
+    def load(self, save_dir, config=None):
+        self._tokenizer = MBartTokenizer.from_pretrained(save_dir, config=config)
+        vocabs = ['<pad>'] + [self._tokenizer.sp_model.id_to_piece(i) for i in
+                              range(self._tokenizer.sp_model.get_piece_size())]
+        self.decoder_vocab = DecoderVocabulary(vocabs, None, pad_token=self._tokenizer.pad_token,
+                                               eos_token=self._tokenizer.eos_token)
+
+class MT5Numericalizer(Seq2SeqNumericalizer):
+    
+    def load(self, save_dir, config=None):
         self._tokenizer = T5Tokenizer.from_pretrained(pretrained_tokenizer, config=config)
-        
         vocabs = [self._tokenizer.sp_model.id_to_piece(i) for i in range(self._tokenizer.sp_model.get_piece_size())]
         self.decoder_vocab = DecoderVocabulary(vocabs, None, pad_token=self._tokenizer.pad_token,
                                                eos_token=self._tokenizer.eos_token)
-    
-    def load(self, save_dir):
-        self._tokenizer = T5Tokenizer.from_pretrained(save_dir)
-        self.decoder_vocab = DecoderVocabulary(self._tokenizer.decoder.values(), None,
-                                               pad_token=self._tokenizer.pad_token, eos_token=self._tokenizer.eos_token)
-    
-    def save(self, save_dir):
-        self._tokenizer.save_pretrained(save_dir)
-    
-    def build_vocab(self, vocab_fields, vocab_sets):
-        raise NotImplementedError
-    
-    def encode_single(self, minibatch, decoder_vocab, device=None, max_length=-1):
-        """
-		minibatch: this method ignores the `mask` component of minibatch
-		"""
-        assert isinstance(minibatch, list)
-        batch_tokens = []
-        for tokens, mask in minibatch:
-            if len(tokens) == 0:
-                batch_tokens.append(' ')
-            else:
-                batch_tokens.append(' '.join(tokens))
-        
-        encoded_batch = self._tokenizer.batch_encode_plus(batch_tokens, add_special_tokens=True, padding=False, return_attention_mask=True)
-        length = torch.sum(torch.tensor(encoded_batch['attention_mask'], dtype=torch.int32, device=device), dim=1)
-        numerical = torch.tensor(encoded_batch['input_ids'], dtype=torch.int64, device=device)
-        
-        decoder_numerical = numerical
-        return SequentialField(length=length, value=numerical, limited=decoder_numerical)
-    
-    def encode_pair(self, minibatch, decoder_vocab, device=None):
-        # TODO
-        raise NotImplementedError
-    
-    def reverse(self, batch, detokenize, field_name=None):
-        _reversed = self._tokenizer.batch_decode(batch, skip_special_tokens=True)
-        return _reversed
-    
-    def decode(self, tensor):
-        return self._tokenizer.convert_ids_to_tokens(tensor)

--- a/genienlp/data_utils/numericalizer/transformer.py
+++ b/genienlp/data_utils/numericalizer/transformer.py
@@ -36,7 +36,7 @@ from .decoder_vocab import DecoderVocabulary
 from .masked_tokenizer import MaskedBertTokenizer, MaskedXLMRobertaTokenizer
 from transformers import BartTokenizer
 from .sequential_field import SequentialField
-from transformers.tokenization_xlnet import SPIECE_UNDERLINE
+from transformers.file_utils import SPIECE_UNDERLINE
 
 class TransformerNumericalizer(object):
     """

--- a/genienlp/models/__init__.py
+++ b/genienlp/models/__init__.py
@@ -27,4 +27,4 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from .general_seq2seq import Transformer2LSTMModel, Bart, MBart, MT5
+from .general_seq2seq import Transformer2LSTM, Bart, MBart, MT5

--- a/genienlp/models/__init__.py
+++ b/genienlp/models/__init__.py
@@ -27,4 +27,4 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from .general_seq2seq import Transformer2LSTMModel, Bart, MT5
+from .general_seq2seq import Transformer2LSTMModel, Bart, MBart, MT5

--- a/genienlp/models/__init__.py
+++ b/genienlp/models/__init__.py
@@ -27,4 +27,4 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from .general_seq2seq import Seq2Seq, Bart
+from .general_seq2seq import Transformer2LSTMModel, Bart, MT5

--- a/genienlp/models/__init__.py
+++ b/genienlp/models/__init__.py
@@ -27,4 +27,4 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from .general_seq2seq import Transformer2LSTM, Bart, MBart, MT5
+from .general_seq2seq import Seq2Seq, Bart, MBart, MT5

--- a/genienlp/models/coatt_encoder.py
+++ b/genienlp/models/coatt_encoder.py
@@ -77,11 +77,11 @@ class CoattentionEncoder(nn.Module):
         context_padding = context.data == self.pad_idx
         question_padding = question.data == self.pad_idx
 
-        context_embedded = self.context_embeddings(context, padding=context_padding).last_layer
+        context_embedded = self.context_embeddings(context, padding=context_padding).last_hidden_state
         context_embedded += positional_encodings_like(context_embedded)
         self_attended_context = self.self_attentive_encoder_context(context_embedded, padding=context_padding)
 
-        question_embedded = self.question_embeddings(question, padding=question_padding).last_layer
+        question_embedded = self.question_embeddings(question, padding=question_padding).last_hidden_state
 
         coattended_context, coattended_question = self.coattention(self_attended_context[-1], question_embedded,
                                                                    context_padding, question_padding)

--- a/genienlp/models/common.py
+++ b/genienlp/models/common.py
@@ -39,11 +39,7 @@ from torch.nn import functional as F
 from torch.nn.utils.rnn import pack_padded_sequence as pack
 from torch.nn.utils.rnn import pad_packed_sequence as unpack
 
-
-class EmbeddingOutput(NamedTuple):
-    all_layers: List[torch.Tensor]
-    last_layer: torch.Tensor
-
+from transformers.modeling_outputs import BaseModelOutputWithPoolingAndCrossAttentions as EmbeddingOutput
 
 INF = 1e10
 EPSILON = 1e-10
@@ -413,29 +409,29 @@ class CombinedEmbedding(nn.Module):
 
     def _combine_embeddings(self, embeddings):
         if len(embeddings) == 1:
-            all_layers = embeddings[0].all_layers
-            last_layer = embeddings[0].last_layer
+            hidden_states = embeddings[0].hidden_states
+            last_hidden_state = embeddings[0].last_hidden_state
             if self.project:
-                last_layer = self.projection(last_layer)
-            return EmbeddingOutput(all_layers=all_layers, last_layer=last_layer)
+                last_hidden_state = self.projection(last_hidden_state)
+            return EmbeddingOutput(hidden_states=hidden_states, last_hidden_state=last_hidden_state)
 
-        all_layers = None
-        last_layer = []
+        hidden_states = None
+        last_hidden_state = []
         for emb in embeddings:
-            if all_layers is None:
-                all_layers = [[layer] for layer in emb.all_layers]
-            elif len(all_layers) != len(emb.all_layers):
+            if hidden_states is None:
+                hidden_states = [[layer] for layer in emb.hidden_states]
+            elif len(hidden_states) != len(emb.hidden_states):
                 raise ValueError('Cannot combine embeddings that use different numbers of layers')
             else:
-                for layer_list, layer in zip(all_layers, emb.all_layers):
+                for layer_list, layer in zip(hidden_states, emb.hidden_states):
                     layer_list.append(layer)
-            last_layer.append(emb.last_layer)
+            last_hidden_state.append(emb.last_hidden_state)
 
-        all_layers = [torch.cat(layer, dim=2) for layer in all_layers]
-        last_layer = torch.cat(last_layer, dim=2)
+        hidden_states = [torch.cat(layer, dim=2) for layer in hidden_states]
+        last_hidden_state = torch.cat(last_hidden_state, dim=2)
         if self.project:
-            last_layer = self.projection(last_layer)
-        return EmbeddingOutput(all_layers=all_layers, last_layer=last_layer)
+            last_hidden_state = self.projection(last_hidden_state)
+        return EmbeddingOutput(hidden_states=hidden_states, last_hidden_state=last_hidden_state)
 
     def forward(self, x, padding=None):
         embedded: List[EmbeddingOutput] = []
@@ -447,7 +443,7 @@ class CombinedEmbedding(nn.Module):
             valid_x = torch.lt(x, trained_vocabulary_size)
             masked_x = torch.where(valid_x, x, torch.zeros_like(x))
             output = self.trained_embeddings(masked_x)
-            embedded.append(EmbeddingOutput(all_layers=[output], last_layer=output))
+            embedded.append(EmbeddingOutput(hidden_states=[output], last_hidden_state=output))
 
         return self._combine_embeddings(embedded)
 

--- a/genienlp/models/common.py
+++ b/genienlp/models/common.py
@@ -29,7 +29,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
-from typing import NamedTuple, List
 
 import torch
 import torch.nn as nn
@@ -431,10 +430,10 @@ class CombinedEmbedding(nn.Module):
         last_hidden_state = torch.cat(last_hidden_state, dim=2)
         if self.project:
             last_hidden_state = self.projection(last_hidden_state)
-        return EmbeddingOutput(hidden_states=hidden_states, last_hidden_state=last_hidden_state)
+        return EmbeddingOutput(hidden_states=tuple(hidden_states), last_hidden_state=last_hidden_state)
 
     def forward(self, x, padding=None):
-        embedded: List[EmbeddingOutput] = []
+        embedded = []
         if self.pretrained_embeddings is not None:
             embedded += [emb(x, padding=padding) for emb in self.pretrained_embeddings]
 
@@ -443,7 +442,7 @@ class CombinedEmbedding(nn.Module):
             valid_x = torch.lt(x, trained_vocabulary_size)
             masked_x = torch.where(valid_x, x, torch.zeros_like(x))
             output = self.trained_embeddings(masked_x)
-            embedded.append(EmbeddingOutput(hidden_states=[output], last_hidden_state=output))
+            embedded.append(EmbeddingOutput(hidden_states=(output,), last_hidden_state=output))
 
         return self._combine_embeddings(embedded)
 

--- a/genienlp/models/general_seq2seq.py
+++ b/genienlp/models/general_seq2seq.py
@@ -57,7 +57,7 @@ DECODERS = {
 
 logger = logging.getLogger(__name__)
 
-class Transformer2LSTMModel(PreTrainedModel):
+class Transformer2LSTM(PreTrainedModel):
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -295,7 +295,7 @@ class Transformer2LSTMModel(PreTrainedModel):
 
         return generated
         
-class Transformer2TransformerModel(torch.nn.Module):
+class Transformer2Transformer(torch.nn.Module):
 
     def __init__(self, **kwargs):
         super().__init__()
@@ -377,7 +377,7 @@ class Transformer2TransformerModel(torch.nn.Module):
 
         return generated
 
-class Bart(Transformer2TransformerModel):
+class Bart(Transformer2Transformer):
 
     def __init__(self, config=None, *inputs, **kwargs):
         super().__init__()
@@ -388,7 +388,7 @@ class Bart(Transformer2TransformerModel):
         self.numericalizer = BartNumericalizer(self.args.seq2seq_decoder)
 
 
-class MBart(Transformer2TransformerModel):
+class MBart(Transformer2Transformer):
     
     def __init__(self, config=None, *inputs, **kwargs):
         super().__init__()
@@ -399,7 +399,7 @@ class MBart(Transformer2TransformerModel):
         self.numericalizer = MBartNumericalizer(self.args.seq2seq_decoder)
 
 
-class MT5(Transformer2TransformerModel):
+class MT5(Transformer2Transformer):
 
     def __init__(self, config=None, *inputs, **kwargs):
         super().__init__()

--- a/genienlp/models/general_seq2seq.py
+++ b/genienlp/models/general_seq2seq.py
@@ -34,14 +34,14 @@ import os
 
 from .coatt_encoder import CoattentionEncoder
 from ..data_utils.embeddings import load_embeddings
-from ..data_utils.numericalizer.transformer import BartNumericalizer
+from ..data_utils.numericalizer.transformer import BartNumericalizer, MT5Numericalizer
 from ..data_utils.example import Example
 from .lstm_encoder import BiLSTMEncoder
 from .mqan_encoder import MQANEncoder
 from .identity_encoder import IdentityEncoder
 from .mqan_decoder import MQANDecoder
 from .common import mask_tokens
-from transformers import PreTrainedModel, PretrainedConfig, BartForConditionalGeneration
+from transformers import PreTrainedModel, PretrainedConfig, BartForConditionalGeneration, MT5ForConditionalGeneration
 
 ENCODERS = {
     'MQANEncoder': MQANEncoder,
@@ -49,14 +49,14 @@ ENCODERS = {
     'Identity': IdentityEncoder,
     'Coattention': CoattentionEncoder,
 }
+
 DECODERS = {
     'MQANDecoder': MQANDecoder
 }
 
 logger = logging.getLogger(__name__)
 
-
-class Seq2Seq(PreTrainedModel):
+class Transformer2LSTMModel(PreTrainedModel):
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -82,7 +82,7 @@ class Seq2Seq(PreTrainedModel):
 
         full_checkpoint_path = os.path.join(save_directory, model_checkpoint_file)
         logger.info(f'Loading the model from {full_checkpoint_path}')
-        model = Seq2Seq(args=args, vocab_sets=vocab_sets, is_loading=True, save_directory=save_directory)
+        model = cls(args=args, vocab_sets=vocab_sets, is_loading=True, save_directory=save_directory)
         save_dict = torch.load(full_checkpoint_path, map_location=device)
         model.load_state_dict(save_dict['model_state_dict'])
 
@@ -120,7 +120,8 @@ class Seq2Seq(PreTrainedModel):
         logger.debug(f'The first 200 tokens:')
         logger.debug(self.numericalizer.vocab.itos[:200])
 
-        self.encoder = ENCODERS[args.seq2seq_encoder](self.numericalizer, args, self.context_embeddings, self.question_embeddings)
+        self.encoder = ENCODERS[args.seq2seq_encoder](self.numericalizer, args, self.context_embeddings,
+                                                      self.question_embeddings)
         self.decoder = DECODERS[args.seq2seq_decoder](self.numericalizer, args, self.decoder_embeddings)
 
         if self.args.pretrain_context > 0:
@@ -178,17 +179,21 @@ class Seq2Seq(PreTrainedModel):
         loss = torch.nn.functional.cross_entropy(context_logits, masked_labels, ignore_index=self.numericalizer.pad_id)
         return (loss, )
 
-    def _normal_forward(self, batch, current_token_id, past_key_values=None, expansion_factor=1, generation_dict=None, encoder_output=None, return_dict=False):
+    def _normal_forward(self, batch, current_token_id, past_key_values=None, expansion_factor=1, generation_dict=None,
+                        encoder_output=None, return_dict=False):
         if encoder_output is None:
-            self_attended_context, final_context, context_rnn_state, final_question, question_rnn_state = self.encoder(batch)
+            self_attended_context, final_context, context_rnn_state, final_question, question_rnn_state = self.encoder(
+                batch)
         else:
             self_attended_context, final_context, context_rnn_state, final_question, question_rnn_state = encoder_output
         encoder_loss = None
+        
         if self.training and getattr(self.args, 'use_encoder_loss', None):
             encoder_loss = self.get_encoder_loss(context_rnn_state)
             
         return self.decoder(batch, self_attended_context, final_context, context_rnn_state,
-                            final_question, question_rnn_state, encoder_loss, current_token_id, decoder_wrapper=past_key_values,
+                            final_question, question_rnn_state, encoder_loss, current_token_id,
+                            decoder_wrapper=past_key_values,
                             expansion_factor=expansion_factor, generation_dict=generation_dict)
 
     def forward(self, batch, pretraining=False, current_token_id=None, past_key_values=None,
@@ -199,8 +204,8 @@ class Seq2Seq(PreTrainedModel):
         if pretraining:
             return self._pretrain_forward(batch)
         else:
-            return self._normal_forward(batch, current_token_id, past_key_values, expansion_factor, generation_dict, encoder_output, return_dict)
-        
+            return self._normal_forward(batch, current_token_id, past_key_values, expansion_factor, generation_dict,
+                                        encoder_output, return_dict)
         
     def get_encoder_loss(self, context_rnn_state):
         
@@ -233,9 +238,12 @@ class Seq2Seq(PreTrainedModel):
     def get_output_embeddings(self):
         return self.decoder.decoder_embeddings
 
-    def prepare_inputs_for_generation(self, input_ids, attention_mask, use_cache, batch, generation_dict, encoder_output, past=None):
+    def prepare_inputs_for_generation(self, input_ids, attention_mask, use_cache, batch, generation_dict,
+                                      encoder_output, past=None):
         expansion_factor = input_ids.shape[0] // len(batch.example_id)
-        return {"batch": batch, "past_key_values": past, "current_token_id": input_ids[:,-1:], "expansion_factor": expansion_factor, "generation_dict": generation_dict, "encoder_output": encoder_output}
+        return {"batch": batch, "past_key_values": past, "current_token_id": input_ids[:, -1:],
+                "expansion_factor": expansion_factor, "generation_dict": generation_dict,
+                "encoder_output": encoder_output}
 
     def _reorder_cache(self, past, beam_idx):
         past.reorder(beam_idx)
@@ -258,7 +266,8 @@ class Seq2Seq(PreTrainedModel):
         self.config.vocab_size = len(batch.decoder_vocab)
         self.config.is_encoder_decoder = False # in order to make it work with `transformers` generation code, we should treat this as a decoder-only model
         batch_size = len(batch.example_id)
-        input_ids = torch.full((batch_size, 1), self.decoder.init_idx, dtype=torch.long, device=batch.context.value.device)
+        input_ids = torch.full((batch_size, 1), self.decoder.init_idx, dtype=torch.long,
+                               device=batch.context.value.device)
         
         generated = super().generate(input_ids=input_ids,
                                      batch=batch,
@@ -279,13 +288,16 @@ class Seq2Seq(PreTrainedModel):
                                      generation_dict={'max_output_length': max_output_length, 'num_beams': num_beams},
                                      encoder_output=encoder_output
                                     )
-        generated = torch.cat((generated[:, 0:1], generated[:, 1:].cpu().apply_(self.decoder.map_to_full).to(batch.context.value.device)), dim=1) # map everything to full vocabulary except BOS which already is in full vocabulary
+        generated = torch.cat(
+            (generated[:, 0:1], generated[:, 1:].cpu().apply_(self.decoder.map_to_full).to(batch.context.value.device)),
+            dim=1)  # map everything to full vocabulary except BOS which already is in full vocabulary
 
         return generated
         
+class Transformer2TransformerModel(torch.nn.Module):
 
-           
-class Bart(torch.nn.Module):
+    def __init__(self, **kwargs):
+        super().__init__()
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
@@ -296,19 +308,11 @@ class Bart(torch.nn.Module):
 
         full_checkpoint_path = os.path.join(save_directory, model_checkpoint_file)
         logger.info(f'Loading the model from {full_checkpoint_path}')
-        model = Bart(args=args)
+        model = cls(args=args)
         save_dict = torch.load(full_checkpoint_path, map_location=device)
         model.load_state_dict(save_dict['model_state_dict'])
 
         return model, save_dict.get('best_decascore')
-
-
-    def __init__(self, config=None, *inputs, **kwargs):
-        super().__init__()
-        assert 'args' in kwargs
-        self.args = kwargs['args']
-        self.bart = BartForConditionalGeneration.from_pretrained(self.args.seq2seq_decoder, cache_dir=self.args.embeddings)
-        self.numericalizer = BartNumericalizer(self.args.seq2seq_decoder)
 
     def forward(self, *input, **kwargs):
         #TODO pretraining
@@ -321,10 +325,11 @@ class Bart(torch.nn.Module):
             y_ids = y[:, :-1].contiguous()
             labels = y[:, 1:].clone()
             labels[y[:, 1:] == pad] = -100
-            return self.bart.forward(source_ids, attention_mask=source_mask, decoder_input_ids=y_ids, labels=labels)
+            return self.base_model.forward(source_ids, attention_mask=source_mask, decoder_input_ids=y_ids,
+                                           labels=labels)
 
         else:
-            return self.bart.forward(**kwargs)
+            return self.base_model.forward(**kwargs)
         
     def set_train_context_embeddings(self, trainable):
         #TODO
@@ -352,7 +357,7 @@ class Bart(torch.nn.Module):
 
         input_ids = batch.context.value
         # TODO attention_mask
-        generated = self.bart.generate(input_ids=input_ids,
+        generated = self.base_model.generate(input_ids=input_ids,
                                      max_length=max_output_length,
                                      min_length=2, # generate at least one token after BOS
                                      bos_token_id=self.numericalizer._tokenizer.bos_token_id,
@@ -370,3 +375,23 @@ class Bart(torch.nn.Module):
                                     )
 
         return generated
+
+class Bart(Transformer2TransformerModel):
+
+    def __init__(self, config=None, *inputs, **kwargs):
+        super().__init__()
+        assert 'args' in kwargs
+        self.args = kwargs['args']
+        self.base_model = BartForConditionalGeneration.from_pretrained(self.args.seq2seq_decoder,
+                                                                       cache_dir=self.args.embeddings)
+        self.numericalizer = BartNumericalizer(self.args.seq2seq_decoder)
+
+class MT5(Transformer2TransformerModel):
+
+    def __init__(self, config=None, *inputs, **kwargs):
+        super().__init__()
+        assert 'args' in kwargs
+        self.args = kwargs['args']
+        self.base_model = MT5ForConditionalGeneration.from_pretrained(self.args.seq2seq_decoder,
+                                                                      cache_dir=self.args.embeddings)
+        self.numericalizer = MT5Numericalizer(self.args.seq2seq_decoder)

--- a/genienlp/models/general_seq2seq.py
+++ b/genienlp/models/general_seq2seq.py
@@ -57,7 +57,7 @@ DECODERS = {
 
 logger = logging.getLogger(__name__)
 
-class Transformer2LSTM(PreTrainedModel):
+class Seq2Seq(PreTrainedModel):
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):

--- a/genienlp/models/general_seq2seq.py
+++ b/genienlp/models/general_seq2seq.py
@@ -34,14 +34,15 @@ import os
 
 from .coatt_encoder import CoattentionEncoder
 from ..data_utils.embeddings import load_embeddings
-from ..data_utils.numericalizer.transformer import BartNumericalizer, MT5Numericalizer
+from ..data_utils.numericalizer.transformer import BartNumericalizer, MBartNumericalizer, MT5Numericalizer
 from ..data_utils.example import Example
 from .lstm_encoder import BiLSTMEncoder
 from .mqan_encoder import MQANEncoder
 from .identity_encoder import IdentityEncoder
 from .mqan_decoder import MQANDecoder
 from .common import mask_tokens
-from transformers import PreTrainedModel, PretrainedConfig, BartForConditionalGeneration, MT5ForConditionalGeneration
+from transformers import PreTrainedModel, PretrainedConfig, BartForConditionalGeneration, MBartForConditionalGeneration, \
+    MT5ForConditionalGeneration
 
 ENCODERS = {
     'MQANEncoder': MQANEncoder,
@@ -385,6 +386,18 @@ class Bart(Transformer2TransformerModel):
         self.base_model = BartForConditionalGeneration.from_pretrained(self.args.seq2seq_decoder,
                                                                        cache_dir=self.args.embeddings)
         self.numericalizer = BartNumericalizer(self.args.seq2seq_decoder)
+
+
+class MBart(Transformer2TransformerModel):
+    
+    def __init__(self, config=None, *inputs, **kwargs):
+        super().__init__()
+        assert 'args' in kwargs
+        self.args = kwargs['args']
+        self.base_model = MBartForConditionalGeneration.from_pretrained(self.args.seq2seq_decoder,
+                                                                        cache_dir=self.args.embeddings)
+        self.numericalizer = MBartNumericalizer(self.args.seq2seq_decoder)
+
 
 class MT5(Transformer2TransformerModel):
 

--- a/genienlp/models/identity_encoder.py
+++ b/genienlp/models/identity_encoder.py
@@ -77,9 +77,9 @@ class IdentityEncoder(nn.Module):
 
         # pick the top-most N transformer layers to pass to the decoder for cross-attention
         # (add 1 to account for the embedding layer - the decoder will drop it later)
-        self_attended_context = context_embedded.all_layers[-(self.args.transformer_layers + 1):]
-        final_context = context_embedded.last_layer
-        final_question = question_embedded.last_layer
+        self_attended_context = context_embedded.hidden_states[-(self.args.transformer_layers + 1):]
+        final_context = context_embedded.last_hidden_state
+        final_question = question_embedded.last_hidden_state
 
         if self.projection is not None:
             final_context = self.dropout(final_context)
@@ -100,10 +100,10 @@ class IdentityEncoder(nn.Module):
                 question_rnn_state = (zero, zero)
             else:
                 if self.args.rnn_zero_state == 'cls':
-                    packed_rnn_state = self.norm(self.pool(context_embedded.last_layer[:, 0, :]))
+                    packed_rnn_state = self.norm(self.pool(context_embedded.last_hidden_state[:, 0, :]))
 
                 elif self.args.rnn_zero_state == 'average':
-                    masked_final_context = context_embedded.last_layer.masked_fill(context_padding.unsqueeze(2), 0)
+                    masked_final_context = context_embedded.last_hidden_state.masked_fill(context_padding.unsqueeze(2), 0)
                     summed_context = torch.sum(masked_final_context, dim=1)
                     average_context = summed_context / context_lengths.unsqueeze(1)
 

--- a/genienlp/models/lstm_encoder.py
+++ b/genienlp/models/lstm_encoder.py
@@ -77,9 +77,9 @@ class BiLSTMEncoder(nn.Module):
 
         # pick the top-most N transformer layers to pass to the decoder for cross-attention
         # (add 1 to account for the embedding layer - the decoder will drop it later)
-        self_attended_context = context_embedded.all_layers[-(self.args.transformer_layers + 1):]
-        final_context = context_embedded.last_layer
-        final_question = question_embedded.last_layer
+        self_attended_context = context_embedded.hidden_states[-(self.args.transformer_layers + 1):]
+        final_context = context_embedded.last_hidden_state
+        final_question = question_embedded.last_hidden_state
 
         final_context, context_rnn_state = self.bilstm_context(final_context, context_lengths)
         context_rnn_state = tuple(self.reshape_rnn_state(x) for x in context_rnn_state)

--- a/genienlp/models/mqan_decoder.py
+++ b/genienlp/models/mqan_decoder.py
@@ -97,7 +97,7 @@ class MQANDecoder(nn.Module):
 
             answer_padding = (answer.data == self.pad_idx)[:, :-1]
 
-            answer_embedded = self.decoder_embeddings(answer[:, :-1], padding=answer_padding).last_layer
+            answer_embedded = self.decoder_embeddings(answer[:, :-1], padding=answer_padding).last_hidden_state
 
             if self.args.transformer_layers > 0:
                 self_attended_decoded = self.self_attentive_decoder(answer_embedded,
@@ -289,7 +289,7 @@ class MQANDecoderWrapper(object):
         if self.mqan_decoder.args.transformer_layers > 0:
             self.hiddens = [self.self_attended_context[0].new_zeros((self.batch_size*expansion_factor, self.max_decoder_time, self.mqan_decoder.args.dimension))
                     for l in range(len(self.mqan_decoder.self_attentive_decoder.layers) + 1)]
-            self.hiddens[0] =  self.hiddens[0] + positional_encodings_like(self.hiddens[0])
+            self.hiddens[0] = self.hiddens[0] + positional_encodings_like(self.hiddens[0])
 
     
     def reorder(self, new_order):
@@ -311,7 +311,7 @@ class MQANDecoderWrapper(object):
 
 
     def next_token_probs(self, current_token_id):
-        embedding = self.mqan_decoder.decoder_embeddings(current_token_id).last_layer
+        embedding = self.mqan_decoder.decoder_embeddings(current_token_id).last_hidden_state
 
         if self.mqan_decoder.args.transformer_layers > 0:
             self.hiddens[0][:, self.time] = self.hiddens[0][:, self.time] + \

--- a/genienlp/models/mqan_encoder.py
+++ b/genienlp/models/mqan_encoder.py
@@ -86,8 +86,8 @@ class MQANEncoder(nn.Module):
         context_padding = context.data == self.pad_idx
         question_padding = question.data == self.pad_idx
 
-        context_embedded = self.encoder_embeddings(context, padding=context_padding).last_layer
-        question_embedded = self.encoder_embeddings(question, padding=question_padding).last_layer
+        context_embedded = self.encoder_embeddings(context, padding=context_padding).last_hidden_state
+        question_embedded = self.encoder_embeddings(question, padding=question_padding).last_hidden_state
 
         context_encoded = self.bilstm_before_coattention(context_embedded, context_lengths)[0]
         question_encoded = self.bilstm_before_coattention(question_embedded, question_lengths)[0]

--- a/genienlp/paraphrase/GPT2Seq2Seq.py
+++ b/genienlp/paraphrase/GPT2Seq2Seq.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import torch
-from transformers.modeling_gpt2 import GPT2LMHeadModel
+from transformers.models.gpt2.modeling_gpt2 import GPT2LMHeadModel
 
 
 class GPT2Seq2Seq(GPT2LMHeadModel):

--- a/genienlp/paraphrase/model_utils.py
+++ b/genienlp/paraphrase/model_utils.py
@@ -8,7 +8,7 @@ import shutil
 import numpy as np
 
 from .transformers_utils import SPIECE_UNDERLINE, MARIAN_GROUP_MEMBERS
-from transformers.tokenization_mbart import FAIRSEQ_LANGUAGE_CODES
+from transformers.models.mbart.tokenization_mbart import FAIRSEQ_LANGUAGE_CODES
 
 from genienlp.metrics import computeBLEU
 

--- a/genienlp/paraphrase/run_generation.py
+++ b/genienlp/paraphrase/run_generation.py
@@ -47,7 +47,8 @@ from .transformers_utils import BART_PRETRAINED_CONFIG_ARCHIVE_MAP, MARIAN_PRETR
 
 from transformers import GPT2Tokenizer, T5Tokenizer, MarianTokenizer, BartTokenizer
 
-from .transformers_utils import GenieMarianMTModel, GenieT5ForConditionalGeneration, GenieBartForConditionalGeneration, GenieMBartForConditionalGeneration
+from .transformers_utils import GenieMarianMTModel, GenieBartForConditionalGeneration, GenieMBartForConditionalGeneration,\
+    GenieT5ForConditionalGeneration, GenieMT5ForConditionalGeneration
 from .transformers_utils import GenieMBartTokenizer
 
 
@@ -69,6 +70,7 @@ ALL_MODELS = sum((tuple(map.keys()) for map in (GPT2_PRETRAINED_CONFIG_ARCHIVE_M
 MODEL_CLASSES = {
     'gpt2': (GPT2Seq2Seq, GPT2Tokenizer, {'bos_token': '<unk>', 'sep_token': '<paraphrase>', 'eos_token': '</paraphrase>'}),
     't5': (GenieT5ForConditionalGeneration, T5Tokenizer, {'bos_token': '<unk>', 'sep_token': '<unk>', 'eos_token': '</s>'}),
+    'mt5': (GenieMT5ForConditionalGeneration, T5Tokenizer, {'bos_token': '<unk>', 'sep_token': '<unk>', 'eos_token': '</s>'}),
     'bart': (GenieBartForConditionalGeneration, BartTokenizer, {'bos_token': '<s>', 'sep_token': '<unk>', 'eos_token': '</s>'}),
     'mbart': (GenieMBartForConditionalGeneration, GenieMBartTokenizer, {'bos_token': '<s>', 'sep_token': '<unk>', 'eos_token': '</s>'}),
     'marian': (GenieMarianMTModel, MarianTokenizer, {'bos_token': '<unk>', 'sep_token': '<unk>', 'eos_token': '</s>'}),

--- a/genienlp/paraphrase/run_lm_finetuning.py
+++ b/genienlp/paraphrase/run_lm_finetuning.py
@@ -195,7 +195,7 @@ def train(args, train_dataset, model, tokenizer, input_file_name=None, multiple_
             segment_ids = segment_ids.to(args.device)
             model.train()
             
-            model_inputs = {'input_ids': inputs, 'position_ids': position_ids, 'token_type_ids': segment_ids, 'use_cache': False}
+            model_inputs = {'input_ids': inputs, 'use_cache': False}
             
             # prepare inputs for mbart, and marian
             if args.model_type in ['mbart', 'marian']:
@@ -210,6 +210,8 @@ def train(args, train_dataset, model, tokenizer, input_file_name=None, multiple_
                 decoder_input_ids = labels.contiguous()
                 decoder_input_ids[decoder_input_ids == args.mlm_ignore_index] = tokenizer.pad_token_id
                 model_inputs['decoder_input_ids'] = decoder_input_ids
+            else:
+                model_inputs.update({'position_ids': position_ids, 'token_type_ids': segment_ids})
 
             outputs = model(**model_inputs)
             lm_logits = outputs[0].contiguous()
@@ -349,7 +351,7 @@ def evaluate(args, model, tokenizer, prefix="", aux=False):
         segment_ids = segment_ids.to(args.device)
 
         with torch.no_grad():
-            model_inputs = {'input_ids': inputs, 'position_ids': position_ids, 'token_type_ids': segment_ids, 'use_cache': False}
+            model_inputs = {'input_ids': inputs, 'use_cache': False}
             
             if args.model_type in ['mbart', 'marian']:
                 model_inputs['attention_mask'] = attention_mask
@@ -361,6 +363,8 @@ def evaluate(args, model, tokenizer, prefix="", aux=False):
                 decoder_input_ids = labels.contiguous()
                 decoder_input_ids[decoder_input_ids == args.mlm_ignore_index] = tokenizer.pad_token_id
                 model_inputs['decoder_input_ids'] = decoder_input_ids
+            else:
+                model_inputs.update({'position_ids': position_ids, 'token_type_ids': segment_ids})
 
             outputs = model(**model_inputs)
             lm_logits = outputs[0]

--- a/genienlp/paraphrase/run_lm_finetuning.py
+++ b/genienlp/paraphrase/run_lm_finetuning.py
@@ -214,7 +214,7 @@ def train(args, train_dataset, model, tokenizer, input_file_name=None, multiple_
                 model_inputs.update({'position_ids': position_ids, 'token_type_ids': segment_ids})
 
             outputs = model(**model_inputs)
-            lm_logits = outputs[0].contiguous()
+            lm_logits = outputs.logits.contiguous()
             assert lm_logits.shape[-1] == model.config.vocab_size
             
             # CrossEntropyLoss ignore_index defaults to -100
@@ -367,7 +367,7 @@ def evaluate(args, model, tokenizer, prefix="", aux=False):
                 model_inputs.update({'position_ids': position_ids, 'token_type_ids': segment_ids})
 
             outputs = model(**model_inputs)
-            lm_logits = outputs[0]
+            lm_logits = outputs.logits
             
             # debugging
             if args.debug:

--- a/genienlp/paraphrase/transformers_utils.py
+++ b/genienlp/paraphrase/transformers_utils.py
@@ -5,10 +5,8 @@ from typing import List, Optional
 
 
 from transformers import LogitsProcessorList
-from transformers.models.marian.modeling_marian import MarianMTModel
-from transformers.models.bart.modeling_bart import BartForConditionalGeneration
-from transformers.models.mbart.modeling_mbart import MBartForConditionalGeneration
-from transformers.models.t5.modeling_t5 import T5ForConditionalGeneration
+from transformers import MarianMTModel, BartForConditionalGeneration, MBartForConditionalGeneration,\
+    T5ForConditionalGeneration, MT5ForConditionalGeneration
 from transformers.modeling_utils import PreTrainedModel
 
 from transformers.models.mbart.tokenization_mbart import MBartTokenizer, _all_mbart_models, SPM_URL
@@ -337,5 +335,9 @@ class GenieMBartForConditionalGeneration(MBartForConditionalGeneration, GeniePre
         super().__init__(config)
 
 class GenieT5ForConditionalGeneration(T5ForConditionalGeneration, GeniePreTrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+
+class GenieMT5ForConditionalGeneration(MT5ForConditionalGeneration, GeniePreTrainedModel):
     def __init__(self, config):
         super().__init__(config)

--- a/genienlp/paraphrase/transformers_utils.py
+++ b/genienlp/paraphrase/transformers_utils.py
@@ -37,6 +37,14 @@ MBART_PRETRAINED_CONFIG_ARCHIVE_MAP = {
     "sshleifer/tiny-mbart": "https://s3.amazonaws.com/models.huggingface.co/bert/sshleifer/tiny-mbart/config.json"
 }
 
+MT5_PRETRAINED_CONFIG_ARCHIVE_MAP = {'google/mt5-{}'.format(v): "https://s3.amazonaws.com/models.huggingface.co/bert/google/mt5-{}/config.json".format(v)
+                                     for v in ['small', 'base', 'large', 'xl', 'xxl']}
+
+
+BART_MODEL_LIST = list(BART_PRETRAINED_CONFIG_ARCHIVE_MAP.keys())
+MBART_MODEL_LIST = list(MBART_PRETRAINED_CONFIG_ARCHIVE_MAP.keys())
+MT5_MODEL_LIST = list(MT5_PRETRAINED_CONFIG_ARCHIVE_MAP.keys())
+
 
 MARIAN_SUPPORTED_LANGUAGES = ['https://huggingface.co/Helsinki-NLP']
 

--- a/genienlp/paraphrase/transformers_utils.py
+++ b/genienlp/paraphrase/transformers_utils.py
@@ -3,14 +3,15 @@ import torch
 import torch.nn.functional as F
 from typing import List, Optional
 
-from transformers.generation_utils import LogitsProcessorList
-from transformers.modeling_marian import MarianMTModel
-from transformers.modeling_bart import BartForConditionalGeneration
-from transformers.modeling_mbart import MBartForConditionalGeneration
-from transformers.modeling_t5 import T5ForConditionalGeneration
+
+from transformers import LogitsProcessorList
+from transformers.models.marian.modeling_marian import MarianMTModel
+from transformers.models.bart.modeling_bart import BartForConditionalGeneration
+from transformers.models.mbart.modeling_mbart import MBartForConditionalGeneration
+from transformers.models.t5.modeling_t5 import T5ForConditionalGeneration
 from transformers.modeling_utils import PreTrainedModel
 
-from transformers.tokenization_mbart import MBartTokenizer, _all_mbart_models, SPM_URL
+from transformers.models.mbart.tokenization_mbart import MBartTokenizer, _all_mbart_models, SPM_URL
 
 SPIECE_UNDERLINE = "▁"
 

--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -134,7 +134,7 @@ def train_step(model, batch, iteration, opt, devices, lr_scheduler=None, grad_cl
                                                iteration > train_question_embeddings_after)
     if (iteration) % gradient_accumulation_steps == 0:
         opt.zero_grad()
-    loss = model(batch, pretraining=pretraining)[0]
+    loss = model(batch, pretraining=pretraining).loss
     if torch.isnan(loss).any():
         raise RuntimeError('Got NaN loss %s', str(loss))
     if len(devices) > 1:

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
         'pyrouge>=0.1.3',
         'sacrebleu~=1.0',
         'requests~=2.22',
-        'transformers==3.5.1',
+        'transformers==4.0.0',
         'sentencepiece>=0.1.91,<0.2.0',
         'mosestokenizer~=1.1',
     ]

--- a/tests/dataset/translation/en-de/dev_t5_aligned.tsv
+++ b/tests/dataset/translation/en-de/dev_t5_aligned.tsv
@@ -1,5 +1,5 @@
 who has a 8 star rating with over 8 reviews in " fonte " ?	wer hat eine 8 Sterne Bewertung mit über 8 Bewertungen in " fonte " ?
-show me nearby hotels with both a " catalan " and " sauna "	ich sah in der Nähe Hotels mit " catalan " und " sauna " .
+show me nearby hotels with both a " catalan " and " sauna "	ich in der Nähe von Hotels mit sowohl " catalan " als auch " sauna " .
 find people graduate of Stanford.	finden Menschen Absolventen von Stanford.
 what is the highest rated hotel ?	Was ist das höchst bewertete Hotel ?
 find hotels with 2 star ratings .	finden Sie Hotels mit 2 Sternenbewertungen .

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -32,6 +32,8 @@ trap on_error ERR INT TERM
 i=0
 for hparams in \
       "--seq2seq_decoder sshleifer/bart-tiny-random --model Bart" \
+      "--seq2seq_decoder sshleifer/tiny-mbart --model MBart" \
+      "--seq2seq_decoder google/mt5-small --model MT5" \
       "--encoder_embeddings=small_glove+char --decoder_embeddings=small_glove+char" \
       "--encoder_embeddings=bert-base-multilingual-uncased --decoder_embeddings= --trainable_decoder_embeddings=50 --seq2seq_encoder=Identity --dimension=768" \
       "--encoder_embeddings=bert-base-uncased --decoder_embeddings= --trainable_decoder_embeddings=50 --seq2seq_encoder MQANEncoder" \


### PR DESCRIPTION
This PR introduces the following changes:
- Code upgrades to make it compatible with latest transformers version (4.0.0)
- Refactoring numericalizer and Seq2Seq models code so we can port new models from _huggingface_ easily.
- Adding MBART and MT5 models to the main training loop following BART's interface.