### PR TITLE
Don't load a pretrained model when loading a fully trained model

### DIFF
--- a/genienlp/models/transformer_lstm.py
+++ b/genienlp/models/transformer_lstm.py
@@ -63,7 +63,10 @@ class TransformerLSTM(GenieModel):
         self.init_vocab_from_data(vocab_sets, tasks, save_directory)
 
         logger.info(f'Initializing encoder and decoder embeddings')
-        self.encoder_embeddings = AutoModel.from_pretrained(encoder_embeddings, config=config, cache_dir=args.embeddings)
+        if save_directory is not None:
+            self.encoder_embeddings = AutoModel.from_config(config)
+        else:
+            self.encoder_embeddings = AutoModel.from_pretrained(encoder_embeddings, config=config, cache_dir=args.embeddings)
         self.encoder_embeddings.resize_token_embeddings(self.numericalizer.num_tokens)
         
         logger.info(f'Vocabulary has {self.numericalizer.num_tokens} tokens')

--- a/genienlp/models/transformer_seq2seq.py
+++ b/genienlp/models/transformer_seq2seq.py
@@ -42,8 +42,11 @@ class TransformerSeq2Seq(GenieModel):
         super().__init__(config)
         self.args = args
         args.dimension = config.d_model
-        self.model = AutoModelForSeq2SeqLM.from_pretrained(self.args.pretrained_model,
-                                                           cache_dir=self.args.embeddings)
+        if save_directory is not None:
+            self.model = AutoModelForSeq2SeqLM.from_config(config)
+        else:
+            self.model = AutoModelForSeq2SeqLM.from_pretrained(self.args.pretrained_model,
+                                                               cache_dir=self.args.embeddings)
         self.numericalizer = TransformerNumericalizer(self.args.pretrained_model, max_generative_vocab=None,
                                                       preprocess_special_tokens=args.preprocess_special_tokens)
         self.init_vocab_from_data(vocab_sets, tasks, save_directory)


### PR DESCRIPTION
If we're loading an existing trained model, we don't need to also
load the pretrained model weights, because they will be overridden
immediately with the finetuned weights. This avoids an expensive
download when doing inference.