### PR TITLE
Wip/version bumps

### DIFF
--- a/genienlp/arguments.py
+++ b/genienlp/arguments.py
@@ -162,6 +162,8 @@ def parse_argv(parser):
     parser.add_argument('--gradient_accumulation_steps', default=1, type=int, help='Number of accumulation steps. Useful to effectively get larger batch sizes.')
     # Loss Truncation; introduced in https://arxiv.org/abs/2004.14589
     parser.add_argument('--dropper_ratio', type=float, default=0.0, help='Ratio of dropped examples in the "Loss Truncation" algorithm. 0 disables truncation.')
+    parser.add_argument('--dropper_min_count', type=int, default=10000,
+                        help='Number of examples to see in the "Loss Truncation" algorithm before starting to drop high-loss examples.')
 
     parser.add_argument('--load', default=None, type=str, help='path to checkpoint to load model from inside --args.save, usually set to best.pth')
     parser.add_argument('--resume', action='store_true', help='whether to resume training with past optimizers')

--- a/genienlp/models/transformer_seq2seq.py
+++ b/genienlp/models/transformer_seq2seq.py
@@ -53,7 +53,7 @@ class TransformerSeq2Seq(GenieModel):
 
         self._is_bart_large = self.args.pretrained_model == 'facebook/bart-large'
         if args.dropper_ratio > 0:
-            self.dropper = LossDropper(dropc=args.dropper_ratio)
+            self.dropper = LossDropper(dropc=args.dropper_ratio, min_count=args.dropper_min_count)
         else:
             self.dropper = None
 

--- a/genienlp/util.py
+++ b/genienlp/util.py
@@ -469,6 +469,8 @@ def load_config_json(args):
                 setattr(args, r, [0.0])
             elif r == 'dropper_ratio':
                 setattr(args, r, 0.0)
+            elif r == 'dropper_min_count':
+                setattr(args, r, 10000)
             else:
                 setattr(args, r, None)
         args.dropout_ratio = 0.0


### PR DESCRIPTION
- Adds `--dropper_min_count` argument which specifies the number of iterations after which loss truncation (if enabled) is applied.
- Fixes two issues that would occur when `--resume` is set:
  - Learning rate scheduler now actually resumes from the correct learning rate instead of restarting.
  - When loading an optimizer that was saved on a GPU machine, a GPU memory surge would happen and the run would crash. This PR solves that.