### PR TITLE
Fix paraphrasing bugs

### DIFF
--- a/genienlp/paraphrase/data_utils.py
+++ b/genienlp/paraphrase/data_utils.py
@@ -28,8 +28,8 @@ special_pattern_mapping = [
                                                           ['$13', 'thirteen dollars', '13 dollars', '$ 13', '$ 13.00', '13.00', '13']]),
     SpecialTokenMap('DURATION_([0-9]+)', ['5 weeks', '6 weeks'], [['5 weeks', 'five weeks'], ['6 weeks', 'six weeks']]),
     SpecialTokenMap('LOCATION_([0-9]+)', ['locatio1n', 'locatio2n'], [['locatio1n', 'locat1n'], ['locatio2n', 'locat2n']]),
-    SpecialTokenMap('QUOTED_STRING_([0-9]+)', lambda x: 'Chinese', lambda x: ['Chinese', 'chinese', 'china']), # TODO change to be more general than cuisine
-    SpecialTokenMap('GENERIC_ENTITY_uk.ac.cam.multiwoz.Restaurant:Restaurant_([0-9]+)', ["restaurant1", "restaurant2", "restaurant3"]) # TODO the only reason we can get away with this unnatural replacement is that actual backward is not going to be called for this
+    # SpecialTokenMap('QUOTED_STRING_([0-9]+)', ['Chinese', 'Italian'], [['Chinese', 'chinese', 'china'], ['Italian', 'italian']]), # TODO change to be more general than cuisine
+    # SpecialTokenMap('GENERIC_ENTITY_uk.ac.cam.multiwoz.Restaurant:Restaurant_([0-9]+)', ["restaurant1", "restaurant2", "restaurant3"]) # TODO the only reason we can get away with this unnatural replacement is that actual backward is not going to be called for this
 ]
 
 

--- a/genienlp/paraphrase/scripts/transform_dataset.py
+++ b/genienlp/paraphrase/scripts/transform_dataset.py
@@ -11,7 +11,7 @@ def is_subset(set1, set2):
     return all([e in set2 for e in set1])
 
 def passes_heuristic_checks(row, args, old_query=None):
-    if 'QUOTED_' in row[args.utterance_column]:
+    if 'QUOTED_STRING' in row[args.utterance_column] or (old_query is not None and 'QUOTED_STRING' in old_query):
         # remove quoted examples
         return False
     if old_query is not None:

--- a/genienlp/paraphrase/scripts/transform_dataset.py
+++ b/genienlp/paraphrase/scripts/transform_dataset.py
@@ -10,7 +10,16 @@ def is_subset(set1, set2):
     """
     return all([e in set2 for e in set1])
 
-def passes_heuristic_checks(row, args):
+def passes_heuristic_checks(row, args, old_query=None):
+    if 'QUOTED_' in row[args.utterance_column]:
+        # remove quoted examples
+        return False
+    if old_query is not None:
+        old_special_tokens = set(re.findall('[A-Za-z:_.]+_[0-9]', old_query))
+        new_special_tokens = set(re.findall('[A-Za-z:_.]+_[0-9]', row[args.utterance_column]))
+        # check that all the special tokens in utterance after paraphrasing are the same as before
+        if set(old_special_tokens) != set(new_special_tokens):
+            return False
     all_input_columns = ' '.join([row[c] for c in args.input_columns])
     input_special_tokens = set(re.findall('[A-Za-z:_.]+_[0-9]', all_input_columns))
     output_special_tokens = set(re.findall('[A-Za-z:_.]+_[0-9]', row[args.thingtalk_column]))
@@ -110,6 +119,7 @@ def main(args):
             seen_examples = set()
         all_thrown_away_rows = []
         for row_idx, row in enumerate(progress_bar(reader, desc='Lines')):
+            old_query = None
             output_rows = []
             thrown_away_rows = []
             if args.transformation == 'remove_thingtalk_quotes':
@@ -136,6 +146,7 @@ def main(args):
                     row[args.utterance_column] = new_query
                     output_rows.append(row)
             elif args.transformation == 'replace_queries':
+                old_query = row[args.utterance_column]
                 for idx, new_query in enumerate(new_queries[row_idx]):
                     copy_row = row.copy()
                     copy_row[args.utterance_column] = new_query
@@ -152,7 +163,7 @@ def main(args):
             for o in output_rows:
                 output_row = ""
                 if args.remove_with_heuristics:
-                    if not passes_heuristic_checks(o, args):
+                    if not passes_heuristic_checks(o, args, old_query=old_query):
                         heuristic_count += 1
                         continue
                 if args.remove_duplicates:
@@ -170,7 +181,7 @@ def main(args):
                         output_row += '\t'
                 output_file.write(output_row + '\n')
             for o in thrown_away_rows:
-                if not args.remove_with_heuristics or (args.remove_with_heuristics and passes_heuristic_checks(o, args)):
+                if not args.remove_with_heuristics or (args.remove_with_heuristics and passes_heuristic_checks(o, args, old_query=old_query)):
                     all_thrown_away_rows.append(o)
 
         if args.thrown_away is not None:

--- a/genienlp/util.py
+++ b/genienlp/util.py
@@ -317,7 +317,7 @@ def unmask_special_tokens(string: str, exceptions: list):
 
 def detokenize(string: str):
     string, exceptions = mask_special_tokens(string)
-    tokens = ["'d", "n't", "'ve", "'m", "'re", "'ll", ".", ",", "?", "!", "'s", ")", ":"]
+    tokens = ["'d", "n't", "'ve", "'m", "'re", "'ll", ".", ",", "?", "!", "'s", ")", ":", "-"]
     for t in tokens:
         string = string.replace(' ' + t, t)
     string = string.replace("( ", "(")
@@ -335,8 +335,9 @@ def tokenize(string: str):
     string = string.replace("(", "( ")
     string = string.replace('gonna', 'gon na')
     string = string.replace('wanna', 'wan na')
-    string = re.sub('\s+', ' ', string)
     string = unmask_special_tokens(string, exceptions)
+    string = re.sub('([A-Za-z:_.]+_[0-9]+)-', r'\1 - ', string) # add space before and after hyphen, e.g. "NUMBER_0-hour"
+    string = re.sub('\s+', ' ', string) # remove duplicate spaces
     return string.strip()
 
 

--- a/genienlp/validate.py
+++ b/genienlp/validate.py
@@ -67,11 +67,12 @@ def generate_with_model(model, data_iterator, numericalizer, task, args,
         batch_size = len(batch.example_id)
         batch_prediction = [[] for _ in range(batch_size)]
         batch_confidence_features = [[] for _ in range(batch_size)]
+        batch_example_ids = batch.example_id
 
-        example_ids += batch.example_id
+        example_ids += batch_example_ids
         if not output_predictions_only:
             batch_answer = numericalizer.reverse(batch.answer.value.data)
-            batch_answer = [task.postprocess_prediction(example_ids[i], batch_answer[i]) for i in range(len(batch_answer))]
+            batch_answer = [task.postprocess_prediction(batch_example_ids[i], batch_answer[i]) for i in range(len(batch_answer))]
             answers += batch_answer
             batch_context = numericalizer.reverse(batch.context.value.data)
             contexts += batch_context
@@ -99,7 +100,7 @@ def generate_with_model(model, data_iterator, numericalizer, task, args,
             partial_batch_prediction = numericalizer.reverse(raw_partial_batch_prediction)
             # post-process predictions
             for i in range(len(partial_batch_prediction)):
-                partial_batch_prediction[i] = task.postprocess_prediction(example_ids[(i//args.num_outputs[hyperparameter_idx]) % batch_size], partial_batch_prediction[i])
+                partial_batch_prediction[i] = task.postprocess_prediction(batch_example_ids[(i//args.num_outputs[hyperparameter_idx]) % batch_size], partial_batch_prediction[i])
             # put them into the right array
             for i in range(len(partial_batch_prediction)):
                 batch_prediction[(i//args.num_outputs[hyperparameter_idx]) % batch_size].append(partial_batch_prediction[i])


### PR DESCRIPTION
Paraphrasing and filtering code had some issues with special tokens, caused by migrating the paraphrasing task from `paraphrase/run_generation.py` to `genienlp/predict.py`.