### PR TITLE
Change batching

### DIFF
--- a/genienlp/data_utils/example.py
+++ b/genienlp/data_utils/example.py
@@ -130,12 +130,15 @@ class Example(object):
     
 
 class NumericalizedExamples(NamedTuple):
+    """
+    Conatains a batch of numericalized (i.e. tokenized and converted to token ids) examples, potentially of size 1
+    """
     example_id: List[str]
     context: SequentialField
     answer: SequentialField
     
     @staticmethod
-    def from_examples(examples, numericalizer):
+    def from_examples(examples: Iterable[Example], numericalizer):
         assert all(isinstance(ex.example_id, str) for ex in examples)
         numericalized_examples = []
         args = numericalizer.args

--- a/genienlp/data_utils/iterator.py
+++ b/genienlp/data_utils/iterator.py
@@ -94,41 +94,36 @@ class LengthSortedIterator(torch.utils.data.Sampler):
     def __next__(self):
         batch_of_indices = []
         current_batch_size = 0
-        i = self._get_next_batch_start_index()
-        if i >= len(self.data_source):
+        candidate_index = self._get_next_batch_start_index()
+        if candidate_index >= len(self.data_source):
             # This is the end of the iterator
             assert not self.shuffle_and_repeat
             raise StopIteration
         while current_batch_size < self.batch_size:
-            new_example = self.data_source[i]
-            if len(batch_of_indices) > 0:
-                longest_example = self.data_source[batch_of_indices[0]] # we sorted in descending order of length, so the first one is the longest
-            else:
-                longest_example = new_example # this is the first element in batch, and therefore the longest
-            examples_size = self.batch_size_fn(longest_example)
-            if examples_size > self.batch_size:
+            candidate_example = self.data_source[candidate_index]
+            if self.batch_size_fn([candidate_example]) > self.batch_size:
                 global _warned_for_batch_size
                 if not _warned_for_batch_size:
                     logger.warning('Skipping an example larger than batch size. Consider increasing the batch size to avoid this warning')
                     _warned_for_batch_size = True
                 self.last_batch_start_index += 1
-                i += 1
-                if i >= len(self.data_source):
+                candidate_index += 1
+                if candidate_index >= len(self.data_source):
                     # This is the end of the iterator
                     assert not self.shuffle_and_repeat
                     raise StopIteration
                 continue
-                
-            new_batch_size = current_batch_size + self.batch_size_fn(longest_example)
-            if new_batch_size > self.batch_size:
+
+            candidate_batch_size = self.batch_size_fn([self.data_source[i] for i in batch_of_indices] + [candidate_example]) # the new batch size if we added this example to the batch
+            if candidate_batch_size > self.batch_size:
                 # the new example would put us over the batch size limit
                 break
 
-            batch_of_indices.append(i)
-            current_batch_size = new_batch_size
-            i += 1
+            batch_of_indices.append(candidate_index)
+            current_batch_size = candidate_batch_size
+            candidate_index += 1
 
-            if i == len(self.data_source):
+            if candidate_index == len(self.data_source):
                 break # don't start from i=0; there is a large difference between the length of the first and last element
 
         self.last_batch_start_index += len(batch_of_indices)

--- a/genienlp/run_bootleg.py
+++ b/genienlp/run_bootleg.py
@@ -238,7 +238,7 @@ def dump_bootleg_features(args, logger):
         t0 = time.time()
         splits, paths = train_task.get_splits(args.data, lower=args.lower, **kwargs)
         t1 = time.time()
-        logger.info('Data loading took {} sec'.format(t1 - t0))
+        logger.info('Data loading took {:.2f} seconds'.format(t1 - t0))
         assert not splits.eval and not splits.test
         if args.use_curriculum:
             assert splits.aux

--- a/genienlp/tasks/almond_task.py
+++ b/genienlp/tasks/almond_task.py
@@ -38,7 +38,7 @@ from ..data_utils.remote_database import RemoteElasticDatabase
 from ..model_utils.translation import compute_attention, replace_quoted_params, force_replace_quoted_params
 from ..tasks.base_dataset import Split
 from ..tasks.base_task import BaseTask
-from ..tasks.generic_dataset import input_then_output_len, input_tokens_fn, CQA, default_batch_fn
+from ..tasks.generic_dataset import input_then_output_len, all_tokens_fn, CQA, default_batch_fn
 from ..tasks.registry import register_task
 from ..data_utils.database import Database
 from ..data_utils.example import Example, get_pad_feature, Feature
@@ -915,7 +915,7 @@ class BaseAlmondMultiLingualTask(BaseAlmondTask):
         else:
             # use default values for `sort_key_fn` and `batch_size_fn`
             sort_key_fn = input_then_output_len
-            batch_size_fn = input_tokens_fn
+            batch_size_fn = all_tokens_fn
         
         groups = len(all_datasets) if kwargs.get('sentence_batching') else None
         

--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -106,7 +106,7 @@ def prepare_data(args, logger):
             splits, paths = task.get_splits(args.data, lower=args.lower, **kwargs)
     
             t1 = time.time()
-            logger.info('Data loading took {} sec'.format(t1-t0))
+            logger.info('Data loading took {:.2f} seconds'.format(t1-t0))
             assert not splits.eval and not splits.test
             if args.use_curriculum:
                 assert splits.aux
@@ -367,7 +367,7 @@ def train(args, devices, model, opt, lr_scheduler, train_sets, train_iterations,
     train_iters = [(task, make_data_loader(dataset, numericalizer, tok, main_device, train=True))
                    for task, dataset, tok in zip(args.train_tasks, train_sets, args.train_batch_tokens)]
     t1 = time.time()
-    logger.info('Preparing iterators took {} sec'.format(t1 - t0))
+    logger.info('Preparing iterators took {:.2f} seconds'.format(t1 - t0))
     
     train_iters = [(task, iter(train_iter)) for task, train_iter in train_iters]
     # save memory

--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -305,11 +305,11 @@ def maybe_save(iteration, model, opt, deca_score, best_decascore, *,
 def do_log_training_loss(iteration, loss, *,
                          lr_scheduler, grad_norm,
                          num_examples, len_contexts, len_answers,
-                         logger, train_task, round_progress, task_progress,
+                         logger, train_task, round_progress, epochs, task_progress,
                          timestamp, writer, log_prefix):
     avg_batch_size = f'avbatch_{num_examples:.0f}_{len_contexts:.0f}_{len_answers:.0f}:'
     logger.info(
-        f'{timestamp}:{elapsed_time(logger)}:iteration_{iteration}:{round_progress}train_{train_task.name}:{task_progress}{avg_batch_size}{log_prefix}/loss_{loss:.4f}')
+        f'{timestamp}:{elapsed_time(logger)}:iteration_{iteration}:epoch_{epochs:.2f}:{round_progress}train_{train_task.name}:{task_progress}{avg_batch_size}{log_prefix}/loss_{loss:.4f}')
 
     if writer is not None:
         writer.add_scalar(f'{log_prefix}/loss/{train_task.name}', loss, iteration)
@@ -351,11 +351,15 @@ def train(args, devices, model, opt, lr_scheduler, train_sets, train_iterations,
     task_iteration = dict()
     task_done = dict()
     task_fraction = dict()
+    task_total_num_examples = dict()
+    task_train_size = dict() # number of examples in each task
 
-    for task in args.train_tasks:
+    for task, train_set in zip(args.train_tasks, train_sets):
         task_iteration[task] = 1
         task_done[task] = False
         task_fraction[task] = 0.0
+        task_total_num_examples[task] = 0.0
+        task_train_size[task] = len(train_set)
 
     saver = Saver(args.log_dir, args.max_to_keep)
     per_task_iterations = 0
@@ -432,7 +436,7 @@ def train(args, devices, model, opt, lr_scheduler, train_sets, train_iterations,
                                              grad_clip=args.grad_clip,
                                              gradient_accumulation_steps=args.gradient_accumulation_steps)
                 if loss is None:
-                    logger.info('Encountered NAN loss during training... Continue training ignoring the current batch')
+                    logger.info('Encountered NAN loss during training. Continue training ignoring the current batch')
                     continue
                 if loss < 1e-6:
                     zero_loss += 1
@@ -453,17 +457,25 @@ def train(args, devices, model, opt, lr_scheduler, train_sets, train_iterations,
                 num_examples += batch.context.value.size(0)
                 len_contexts += batch.context.value.size(1)
                 len_answers += batch.answer.value.size(1)
+                
+                task_total_num_examples[task] += batch.context.value.size(0)
     
                 if should_log(iteration, log_every):
                     local_loss /= log_every
                     num_examples /= log_every
                     len_contexts /= log_every
                     len_answers /= log_every
-                    do_log_training_loss(iteration, local_loss,
-                                         lr_scheduler=lr_scheduler, grad_norm=grad_norm,
+                    do_log_training_loss(iteration, 
+                                         local_loss,
+                                         lr_scheduler=lr_scheduler,
+                                         grad_norm=grad_norm,
                                          num_examples=num_examples, len_contexts=len_contexts, len_answers=len_answers,
-                                         logger=logger, writer=writer, train_task=task, round_progress=round_progress,
-                                         task_progress=task_progress, timestamp=args.timestamp, log_prefix=log_prefix)
+                                         logger=logger, writer=writer, train_task=task,
+                                         round_progress=round_progress,
+                                         epochs=task_total_num_examples[task]/task_train_size[task],
+                                         task_progress=task_progress,
+                                         timestamp=args.timestamp,
+                                         log_prefix=log_prefix)
                     num_examples = 0
                     len_contexts = 0
                     len_answers = 0

--- a/tests/test_NED.sh
+++ b/tests/test_NED.sh
@@ -15,7 +15,7 @@ for hparams in \
 do
 
     # train
-    genienlp train --train_tasks almond_dialogue_nlu --train_batch_tokens 50 --val_batch_size 50 --train_iterations 6 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --database_dir $SRCDIR/database/ --data $SRCDIR/dataset/thingpedia_99/ --bootleg_output_dir $SRCDIR/dataset/thingpedia_99/bootleg/  --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit --do_ned --database_type json --ned_features type_id type_prob --ned_features_size 1 1 --ned_features_default_val 0 1.0 --num_workers 0 --min_entity_len 2 --max_entity_len 4 $hparams
+    genienlp train --train_tasks almond_dialogue_nlu --train_batch_tokens 100 --val_batch_size 100 --train_iterations 6 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --database_dir $SRCDIR/database/ --data $SRCDIR/dataset/thingpedia_99/ --bootleg_output_dir $SRCDIR/dataset/thingpedia_99/bootleg/  --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit --do_ned --database_type json --ned_features type_id type_prob --ned_features_size 1 1 --ned_features_default_val 0 1.0 --num_workers 0 --min_entity_len 2 --max_entity_len 4 $hparams
 
     # greedy prediction
     genienlp predict --tasks almond_dialogue_nlu --evaluate valid --path $workdir/model_$i --overwrite --eval_dir $workdir/model_$i/eval_results/ --database_dir $SRCDIR/database/ --data $SRCDIR/dataset/thingpedia_99/ --embeddings $EMBEDDING_DIR --skip_cache

--- a/tests/test_calibration.sh
+++ b/tests/test_calibration.sh
@@ -9,7 +9,7 @@ for hparams in \
 do
 
     # train
-    genienlp train --train_tasks almond --train_batch_tokens 50 --val_batch_size 50 --train_iterations 6 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $SRCDIR/dataset/  $hparams --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
+    genienlp train --train_tasks almond --train_batch_tokens 100 --val_batch_size 100 --train_iterations 6 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $SRCDIR/dataset/  $hparams --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
 
     # greedy prediction
     genienlp predict --tasks almond --evaluate test --path $workdir/model_$i --overwrite --eval_dir $workdir/model_$i/eval_results/ --data $SRCDIR/dataset/ --embeddings $EMBEDDING_DIR --skip_cache --save_confidence_features --confidence_feature_path $workdir/model_$i/confidences.pkl --mc_dropout_num 10

--- a/tests/test_kfserver.sh
+++ b/tests/test_kfserver.sh
@@ -9,7 +9,7 @@ for hparams in \
 do
 
     # train
-    genienlp train --train_tasks almond --train_batch_tokens 50 --val_batch_size 50 --train_iterations 6 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $SRCDIR/dataset/  $hparams --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
+    genienlp train --train_tasks almond --train_batch_tokens 100 --val_batch_size 100 --train_iterations 6 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $SRCDIR/dataset/  $hparams --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
 
     # run kfserver in background
     (genienlp kfserver --path $workdir/model_$i)&

--- a/tests/test_main_almond.sh
+++ b/tests/test_main_almond.sh
@@ -13,7 +13,7 @@ for hparams in \
 do
 
     # train
-    genienlp train --train_tasks almond --train_batch_tokens 50 --val_batch_size 50 --train_iterations 4 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $SRCDIR/dataset/  $hparams --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
+    genienlp train --train_tasks almond --train_batch_tokens 100 --val_batch_size 100 --train_iterations 4 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $SRCDIR/dataset/  $hparams --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
 
     # greedy prediction
     genienlp predict --tasks almond --evaluate test --path $workdir/model_$i --overwrite --eval_dir $workdir/model_$i/eval_results/ --data $SRCDIR/dataset/ --embeddings $EMBEDDING_DIR --skip_cache

--- a/tests/test_main_almond_multilingual.sh
+++ b/tests/test_main_almond_multilingual.sh
@@ -11,7 +11,7 @@ for hparams in \
 do
 
     # train
-    genienlp train --train_tasks almond_multilingual --train_languages fa+en --eval_languages fa+en --train_batch_tokens 50 --val_batch_size 50 --train_iterations 4 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $SRCDIR/dataset/  $hparams --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
+    genienlp train --train_tasks almond_multilingual --train_languages fa+en --eval_languages fa+en --train_batch_tokens 100 --val_batch_size 100 --train_iterations 4 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $SRCDIR/dataset/  $hparams --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
 
     # greedy decode
     # combined evaluation

--- a/tests/test_paraphrasing.sh
+++ b/tests/test_paraphrasing.sh
@@ -9,7 +9,7 @@ for hparams in \
       "--model TransformerSeq2Seq --pretrained_model sshleifer/bart-tiny-random"; do
 
     # train
-    genienlp train --train_tasks almond_natural_seq2seq --train_batch_tokens 50 --val_batch_size 50 --train_iterations 6 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $SRCDIR/dataset/  $hparams --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
+    genienlp train --train_tasks almond_natural_seq2seq --train_batch_tokens 100 --val_batch_size 100 --train_iterations 6 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $SRCDIR/dataset/  $hparams --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
 
     # greedy prediction
     genienlp predict --tasks almond_paraphrase --evaluate test --path $workdir/model_$i --overwrite --eval_dir $workdir/model_$i/eval_results/ --data $SRCDIR/dataset/ --embeddings $EMBEDDING_DIR --skip_cache

--- a/tests/test_translation.sh
+++ b/tests/test_translation.sh
@@ -21,7 +21,7 @@ for model in "Helsinki-NLP/opus-mt-en-de" "sshleifer/tiny-mbart" ; do
     cp $workdir/translation/almond/train.tsv $workdir/translation/almond/eval.tsv
 
     # train
-    genienlp train  --train_tasks almond_translate --train_languages en --train_tgt_languages de --eval_languages en --eval_tgt_languages de --model TransformerSeq2Seq --pretrained_model $model --train_batch_tokens 50 --val_batch_size 50 --train_iterations 6 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $workdir/translation/ --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
+    genienlp train  --train_tasks almond_translate --train_languages en --train_tgt_languages de --eval_languages en --eval_tgt_languages de --model TransformerSeq2Seq --pretrained_model $model --train_batch_tokens 100 --val_batch_size 100 --train_iterations 6 --preserve_case --save_every 2 --log_every 2 --val_every 2 --save $workdir/model_$i --data $workdir/translation/ --exist_ok --skip_cache --embeddings $EMBEDDING_DIR --no_commit
 
     # greedy prediction
     genienlp predict --tasks almond_translate --evaluate valid --pred_languages en --pred_tgt_languages de --path $workdir/model_$i --overwrite --eval_dir $workdir/model_$i/eval_results/ --data $workdir/translation/ --embeddings $EMBEDDING_DIR --skip_cache


### PR DESCRIPTION
This PR changes the way we batch examples:
- Like before, examples are sorted based on their input (question+context) length and if tied, by output (answer) length.
However, during batching, the batch size is calculated as number of all tokens in the batch (input and output tokens, including pad tokens).
- This reduces the fluctuation in GPU memory use between different batches.
- Increase `--train_batch_tokens` and `--val_batch_size` in your experiments by a factor of 4. You should try a few values for each task to find the maximum number that does not result in OOM. Then lower the number of iterations.
For instance, `--train_batch_tokens 1500 --val_batch_size 2000` works for the `almond_dialogue_nlu` task when using BART-large (it was `--train_batch_tokens 400`). This in practice translates to a ~60% increase in the number of examples that can fit into each batch, and a ~25% decrease in speed per batch (dues to bigger batches). So overall, it improves training speed for a fixed number of examples by ~28%.
- This PR also logs the epoch number at each log step, which is (number of seen examples) / (size of the dataset).