### PR TITLE
Use wip/neural branch for bootleg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setuptools.setup(
         # for kf
         'kfserving>=0.5.0',
         # for NED
-        'bootleg==1.0.2',
+        'bootleg @ git+https://github.com/Mehrad0711/bootleg@c48e5e51015e001a95d5ed9b33f53f4e58f6de9b',
         'marisa_trie_m==0.7.6',
         'elasticsearch==7.13.2',
         # for calibration:


### PR DESCRIPTION
Changes to bootleg:
- Fixing memory issues by memory mapping all large files (addressing #156)
- hotfix for missing titles for certain Qids
- fix device assertion

Have to bring git dependencies back until bootleg pushes a new release.
Code is tested on kubeflow using thingpedia 121 dataset.