### PR TITLE
train: don't map save_dict to cpu before saving

### DIFF
--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -295,8 +295,6 @@ def maybe_save(
         # to load this model later
         model_state_dict = model.module.state_dict()
 
-    model_state_dict = {k: v.cpu() for k, v in model_state_dict.items()}
-
     save_model_state_dict = {'model_state_dict': model_state_dict, 'best_decascore': best_decascore}
     save_opt_state_dict = opt.state_dict()
     save_opt_state_dict.update({'start_iteration': iteration})


### PR DESCRIPTION
PR pitch:

Have you ever noticed genienlp checkpoints suspiciously take twice the disk space of their corresponding pretrained model?
Well, if not, don't worry cause you won't notice it anymore!