### PR TITLE
Redo bootleg analysis scripts

### DIFF
--- a/genienlp/ned/abstract.py
+++ b/genienlp/ned/abstract.py
@@ -86,9 +86,9 @@ class AbstractEntityDisambiguator(object):
         for normalized_type, titles in self.almond_type_mapping.items():
             for title in titles:
                 if re.search(r'[.?*]', title):
-                    inclusions.append((title, normalized_type))
+                    inclusions.append((re.compile(fnmatch.translate(title)), normalized_type))
                 else:
-                    matches.append((title, normalized_type))
+                    matches.append((re.compile(fnmatch.translate(title)), normalized_type))
 
         # do wildcard matching only after going through all exact matches
         self.wiki2normalized_type.extend(matches)
@@ -98,7 +98,7 @@ class AbstractEntityDisambiguator(object):
         norm_type = None
         type = type.lower()
         for pair in self.wiki2normalized_type:
-            if fnmatch.fnmatch(type, pair[0]):
+            if pair[0].fullmatch(type):
                 norm_type = pair[1]
                 break
         return norm_type

--- a/genienlp/ned/database_files/banned_phrases.txt
+++ b/genienlp/ned/database_files/banned_phrases.txt
@@ -191,3 +191,9 @@ home assistant
 key words
 keywords
 list of books
+end of
+price
+fan
+bing
+power on
+release year

--- a/genienlp/ned/main.py
+++ b/genienlp/ned/main.py
@@ -36,6 +36,7 @@ import ujson
 from ..data_utils.almond_utils import quoted_pattern_with_space
 from ..ned.ned_utils import has_overlap, is_banned, normalize_text
 from .abstract import AbstractEntityDisambiguator
+from ..util import find_span
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +185,7 @@ class EntityOracleEntityDisambiguator(BaseEntityDisambiguator):
 class EntityAndTypeOracleEntityDisambiguator(BaseEntityDisambiguator):
     def __init__(self, args):
         super().__init__(args)
+        self._unrecognized_types = set()
 
     def find_type_ids(self, tokens, answer, aliases=None):
         entity2type = self.collect_answer_entity_types(tokens, answer)
@@ -212,86 +214,113 @@ class EntityAndTypeOracleEntityDisambiguator(BaseEntityDisambiguator):
 
         return tokens_type_ids
 
+    def _get_entity_type(self, current_domain, current_function, answer_tokens, string_begin, string_end):
+        # identify the type of this string based on the surrounding tokens
+        type = None
+        if string_begin >= 3 and answer_tokens[string_begin-2] == '(' and answer_tokens[string_begin-3] == 'Location':
+            # new Location ( " ...
+            type = 'Location'
+        elif string_begin >= 3 and answer_tokens[string_begin-2] == '(' and answer_tokens[string_begin-3].startswith('^^'):
+            # null ^^com.foo ( " ...
+            prefix, suffix = answer_tokens[string_begin-3].rsplit(':', 1)
+            if prefix != '^^tt':
+                type = prefix.rsplit('.', 1)[-1] + ' ' + suffix
+            else:
+                type = suffix
+
+            if (
+                type == 'Person'
+                and string_begin >= 6 and answer_tokens[string_begin-6] in ('director', 'creator', 'actor')
+            ):
+                # (director|creator|actor) == null ^^org.schema:Person ( " ...
+                type = current_domain + ' ' + answer_tokens[string_begin-6]
+        elif string_begin >= 3 and answer_tokens[string_begin-2] == '=~' and answer_tokens[string_begin-3] == 'id':
+            type = current_domain + ' ' + current_function
+        elif string_begin >= 5 and answer_tokens[string_begin-2] == '=' and answer_tokens[string_begin-3] == 'name' \
+            and answer_tokens[string_begin-4] == '(' and answer_tokens[string_begin-5].startswith('@'):
+            type = current_domain + ' name'
+        elif string_begin >= 3 and answer_tokens[string_begin-2] in ('=', '==', '=~'):
+            # foo == " ...
+            # foo = "
+            type = current_domain + ' ' + answer_tokens[string_begin-3]
+        elif string_begin >= 5 and answer_tokens[string_begin-5] in ('contains', 'contains~'):
+            # contains ( foo , " ...
+            type = current_domain + ' ' + answer_tokens[string_begin-3]
+        elif string_begin >= 2 and answer_tokens[string_begin-2] in (',', '['):
+            # in_array ( foo , [ " ...
+            # traverse back until reach beginning of list
+            i = string_begin-2
+            while answer_tokens[i] != '[' and i > 0:
+                i -= 1
+            if i > 4 and answer_tokens[i - 4] in ('in_array', 'in_array~'):
+                if answer_tokens[i - 2] == 'id':
+                    type = current_domain + ' ' + current_function
+                else:
+                    type = current_domain + ' ' + answer_tokens[i - 2]
+
+        if type:
+            type = type.replace('_', ' ')
+        return type
+
     def collect_answer_entity_types(self, tokens, answer):
         entity2type = dict()
-        sentence = ' '.join(tokens)
 
-        answer_entities = quoted_pattern_with_space.findall(answer)
-        for ent in answer_entities:
-            # skip examples with sentence-annotation entity mismatch. hopefully there's not a lot of them.
-            # this is usually caused by paraphrasing where it adds "-" after entity name: "korean-style restaurants"
-            # or add "'" before or after an entity
-            if not re.search(rf'(^|\s){ent}($|\s)', sentence):
-                continue
+        string_begin = None
+        answer_tokens = answer.split(' ')
+        current_domain = None
+        current_function = None
 
-            # ** this should change if thingtalk syntax changes **
-            # ( ... [Book|Music|...] ( ) filter id =~ " position and affirm " ) ...'
-            # ... ^^org.schema.Book:Person ( " james clavell " ) ...
-            # ... contains~ ( [award|genre|...] , " booker " ) ...
-            # ... inLanguage =~ " persian " ...
-
-            idx = answer.index('" ' + ent + ' "')
-
-            type = None
-            tokens_before_entity = answer[:idx].split()
-
-            if tokens_before_entity[-2] == 'Location':
-                type = 'Location'
-
-            elif tokens_before_entity[-1] in ['>=', '==', '<='] and tokens_before_entity[-2] in [
-                'ratingValue',
-                'reviewCount',
-                'checkoutTime',
-                'checkinTime',
-                'contentRating',
-            ]:
-                type = tokens_before_entity[-2]
-
-            elif tokens_before_entity[-1] == '=~':
-                if tokens_before_entity[-2] in ['id', 'value']:
-                    # travers previous tokens until find filter
-                    i = -3
-                    while tokens_before_entity[i] != 'filter' and -(i - 3) < len(tokens_before_entity):
-                        i -= 1
-                    type = tokens_before_entity[i - 3]
+        for i, token in enumerate(answer_tokens):
+            if token == '"':
+                if string_begin is None:
+                    # opening a quoted string
+                    string_begin = i+1
                 else:
-                    type = tokens_before_entity[-2]
+                    # closing a quoted string
+                    if i == string_begin:
+                        string_begin = None
+                        continue
+                    # skip examples with sentence-annotation entity mismatch. hopefully there's not a lot of them.
+                    # this is usually caused by paraphrasing where it adds "-" after entity name: "korean-style restaurants"
+                    # or add "'" before or after an entity
+                    string_end = i
+                    entity = answer_tokens[string_begin:string_end]
+                    if find_span(tokens, entity) is None:
+                        string_begin = None
+                        continue
 
-            elif tokens_before_entity[-4] == 'contains~':
-                type = tokens_before_entity[-2]
+                    type = self._get_entity_type(current_domain, current_function, answer_tokens, string_begin, string_end)
+                    if type and type.split(' ')[-1] in ('title', 'message', 'description', 'status', 'query', 'contents', 'keyword', 'text'):
+                        # free text
+                        string_begin = None
+                        continue
 
-            elif tokens_before_entity[-2].startswith('^^'):
-                type = tokens_before_entity[-2].rsplit(':', 1)[1]
-                if (
-                    type == 'Person'
-                    and tokens_before_entity[-3] == 'null'
-                    and tokens_before_entity[-5] in ['director', 'creator', 'actor']
-                ):
-                    type = tokens_before_entity[-5]
-
-            elif tokens_before_entity[-1] == ',' and tokens_before_entity[-2] in ['award']:
-                type = 'award'
-
-            elif tokens_before_entity[-1] in [',', '[']:
-                # traverse back until reach beginning of list
-                i = -1
-                while tokens_before_entity[i] != '[' and -(i - 2) < len(tokens_before_entity):
-                    i -= 1
-                if tokens_before_entity[i - 1] == ',':
-                    type = tokens_before_entity[i - 2]
-                else:
-                    type = 'keywords'
-
-            if type:
-                norm_type = self.normalize_types(type)
-                assert norm_type in self.type_vocab_to_typeqid, f'{norm_type}, {answer}'
-            else:
-                print(f'{type}, {answer}')
-                continue
-
-            entity2type[ent] = norm_type
-
-            self.all_schema_types.add(norm_type)
+                    if type:
+                        norm_type = self.normalize_types(type)
+                        if norm_type:
+                            assert norm_type in self.type_vocab_to_typeqid, f'{norm_type}, {answer}'
+                            entity2type[' '.join(entity)] = norm_type
+                            self.all_schema_types.add(norm_type)
+                        elif type not in self._unrecognized_types:
+                            logger.info("skipped unrecognized type '%s' in %s", type, answer)
+                            self._unrecognized_types.add(type)
+                    else:
+                        logger.warn('could not identify type: %s', answer)
+                    string_begin = None
+            elif token.startswith('@'):
+                current_domain = answer_tokens[i].rsplit('.', 1)[1]
+                # parse:
+                # @com.foo ( ... ) . bar
+                # or
+                # @com.foo . bar
+                j = i
+                if answer_tokens[j+1] == '(':
+                    # we have a device name, skip to the closing parenthesis
+                    j += 2
+                    while j < len(answer_tokens) and answer_tokens[j] != ')':
+                        j += 1
+                if j+2 < len(answer_tokens):
+                    current_function = answer_tokens[j+2]
 
         return entity2type
 

--- a/genienlp/ned/scripts/analyze_bootleg_results.py
+++ b/genienlp/ned/scripts/analyze_bootleg_results.py
@@ -1,6 +1,7 @@
 from collections import Counter
 
 import jsonlines
+from tqdm import tqdm
 
 from genienlp.ned.bootleg import BatchBootlegEntityDisambiguator
 
@@ -36,14 +37,14 @@ def main(args):
 
     bootleg = BatchBootlegEntityDisambiguator(args)
 
-    lines = jsonlines.open(args.input_file, 'r')
+    lines = list(jsonlines.open(args.input_file, 'r'))
 
     all_titles = Counter()
     all_new_titles = Counter()
 
     fout = open(args.output_file, 'w')
 
-    for count, bootleg_line in enumerate(lines):
+    for count, bootleg_line in enumerate(tqdm(lines)):
         if count >= args.subsample:
             break
 

--- a/genienlp/ned/scripts/oracle_vs_bootleg.py
+++ b/genienlp/ned/scripts/oracle_vs_bootleg.py
@@ -1,6 +1,7 @@
 from collections import Counter, defaultdict
 
 import jsonlines
+from tqdm import tqdm
 
 from genienlp.ned import BatchBootlegEntityDisambiguator
 
@@ -16,36 +17,48 @@ def parse_argv(parser):
     parser.add_argument('--bootleg_output_dir', type=str, default='results_temp')
     parser.add_argument('--embeddings', type=str, default='.embeddings')
     parser.add_argument('--almond_type_mapping_path', type=str)
-
+    parser.add_argument('--ned_normalize_types', type=str, choices=['no', 'soft', 'strict'], default='strict')
 
 def main(args):
 
-    # args.ned_normalize_types = 'soft'
-    # args.bootleg_prob_threshold = 0.3
-    # args.max_types_per_qid = 1
-    # args.max_qids_per_entity = 1
-
-    args.ned_normalize_types = 'strict'
-    args.bootleg_prob_threshold = 0.01
+    args.root = '.'
+    #args.bootleg_prob_threshold = 0.01
+    args.bootleg_prob_threshold = 0.3
     args.max_types_per_qid = 2
-    args.max_qids_per_entity = 2
+    args.max_qids_per_entity = 1
 
     args.max_features_size = args.max_types_per_qid * args.max_qids_per_entity
 
     bootleg = BatchBootlegEntityDisambiguator(args)
 
+    n_lines = 0
+    with open(args.bootleg_labels) as fp:
+        for line in fp:
+            n_lines += 1
+
     bootleg_lines = jsonlines.open(args.bootleg_labels, 'r')
     oracle_lines = jsonlines.open(args.oracle_labels, 'r')
 
-    not_detected = Counter()
-    no_TT_type = Counter()
-    not_correct = Counter()
+    # the entity was there in the oracle and bootleg detected it with the right type
+    strict_true_positive = Counter()
+    # the entity was there in the oracle and bootleg detected it with the wrong type
+    # (this is a false negative when ned_normalize_types == strict
+    # and a true positive when ned_normalize_types === soft)
+    soft_true_positive = Counter()
+    # bootleg did not the detect an entity that was in the oracle
+    false_negative = Counter()
 
-    fout = open(args.output_file, 'w')
+    # same as soft_true_positive, but indexed by bootleg_type not oracle_type
+    precision_true_positive = Counter()
+    # bootleg detected the entity but the entity was not there in the oracle
+    false_positive = Counter()
 
-    for oracle_line, bootleg_line in zip(oracle_lines, bootleg_lines):
+    mismatched_types = defaultdict(Counter)
+    mispredicted_entities = defaultdict(Counter)
 
-        assert len(oracle_line['sentence'].split(' ')) == len(bootleg_line['sentence'].split(' '))
+    for oracle_line, bootleg_line in tqdm(zip(oracle_lines, bootleg_lines), total=n_lines):
+
+        assert oracle_line['sentence'] == bootleg_line['sentence']
 
         # oracle
         entity2types_oracle = defaultdict(str)
@@ -64,32 +77,68 @@ def main(args):
 
             entity2types_bootleg[alias] = type_vocabs
 
-        for k_oracle, v_oracle in entity2types_oracle.items():
+        for oracle_entity, oracle_type in entity2types_oracle.items():
             detected = False
-            for k_boot in entity2types_bootleg.keys():
-                if k_oracle in k_boot or k_boot in k_oracle:
+            for bootleg_entity in entity2types_bootleg.keys():
+                if oracle_entity in bootleg_entity or bootleg_entity in oracle_entity:
+                    # consider it detected as long as it overlaps in some way
                     detected = True
+
+                    correct_type = oracle_type in entity2types_bootleg[bootleg_entity]
+
+                    soft_true_positive[oracle_type] += 1
+                    for bootleg_type in entity2types_bootleg[bootleg_entity]:
+                        precision_true_positive[bootleg_type] += 1
+                    if correct_type:
+                        strict_true_positive[oracle_type] += 1
+                    else:
+                        for bootleg_type in entity2types_bootleg[bootleg_entity]:
+                            mismatched_types[oracle_type][bootleg_type] += 1
                     break
 
-            if detected:
-                if len(entity2types_bootleg[k_boot]) == 0:
-                    no_TT_type[k_oracle] += 1
-                elif v_oracle not in entity2types_bootleg[k_boot]:
-                    not_correct[k_oracle] += 1
-                    fout.write(
-                        f'TT type for {k_oracle}: {entity2types_oracle[k_oracle]} ; {k_boot}: {entity2types_bootleg[k_boot]}'
-                        + '\n'
-                    )
-            else:
-                not_detected[k_oracle] += 1
+            if not detected:
+                false_negative[oracle_type] += 1
 
-    fout.close()
+        for bootleg_entity, bootleg_types in entity2types_bootleg.items():
+            is_true_entity = False
+            for oracle_entity in entity2types_oracle.keys():
+                if oracle_entity in bootleg_entity or bootleg_entity in oracle_entity:
+                    # consider it a true entity as long as it overlaps in some way
+                    is_true_entity = True
+                    break
 
-    print(f'not_detected: {not_detected}')
-    print(f'no TT type detected: {no_TT_type}')
-    print(f'not_correct: {not_correct}')
+            if not is_true_entity:
+                for bootleg_type in bootleg_types:
+                    false_positive[bootleg_type] += 1
+                    mispredicted_entities[bootleg_type][bootleg_entity] += 1
 
-    all_wrong = sum(not_detected.values()) + sum(no_TT_type.values()) + sum(not_correct.values())
-    print(f'not_detected: {sum(not_detected.values()) / all_wrong}')
-    print(f'no TT type detected: {sum(no_TT_type.values()) / all_wrong}')
-    print(f'not_correct: {sum(not_correct.values()) / all_wrong}')
+    keys = list(set(strict_true_positive.keys()) | set(soft_true_positive.keys()) | \
+        set(false_negative.keys()))
+    keys.sort()
+
+    for k in keys:
+        if precision_true_positive[k] + false_positive[k] != 0:
+            precision = precision_true_positive[k] / (precision_true_positive[k] + false_positive[k])
+        else:
+            precision = 'n/a'
+        if strict_true_positive[k] + false_negative[k] != 0:
+            strict_recall = strict_true_positive[k] / (strict_true_positive[k] + false_negative[k])
+        else:
+            strict_recall = 'n/a'
+        if soft_true_positive[k] + false_negative[k] != 0:
+            soft_recall = soft_true_positive[k] / (soft_true_positive[k] + false_negative[k])
+        else:
+            soft_recall = 'n/a'
+
+        print(k, precision, strict_recall, soft_recall, sep='\t')
+
+    print()
+    for k in keys:
+        print(k, ':')
+        print('mispredicted types')
+        for bootleg_k in mismatched_types[k].most_common(5):
+            print(bootleg_k)
+        print('unnecessary entities')
+        for bootleg_k in mispredicted_entities[k].most_common(5):
+            print(bootleg_k)
+        print()

--- a/genienlp/ned/scripts/oracle_vs_bootleg.py
+++ b/genienlp/ned/scripts/oracle_vs_bootleg.py
@@ -19,10 +19,11 @@ def parse_argv(parser):
     parser.add_argument('--almond_type_mapping_path', type=str)
     parser.add_argument('--ned_normalize_types', type=str, choices=['no', 'soft', 'strict'], default='strict')
 
+
 def main(args):
 
     args.root = '.'
-    #args.bootleg_prob_threshold = 0.01
+    # args.bootleg_prob_threshold = 0.01
     args.bootleg_prob_threshold = 0.3
     args.max_types_per_qid = 2
     args.max_qids_per_entity = 1
@@ -112,8 +113,7 @@ def main(args):
                     false_positive[bootleg_type] += 1
                     mispredicted_entities[bootleg_type][bootleg_entity] += 1
 
-    keys = list(set(strict_true_positive.keys()) | set(soft_true_positive.keys()) | \
-        set(false_negative.keys()))
+    keys = list(set(strict_true_positive.keys()) | set(soft_true_positive.keys()) | set(false_negative.keys()))
     keys.sort()
 
     for k in keys:

--- a/genienlp/tasks/__init__.py
+++ b/genienlp/tasks/__init__.py
@@ -27,4 +27,4 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from . import almond_task, generic_task, hf_task
+from . import almond_task, generic_task, hf_task  # noqa

--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -659,6 +659,13 @@ def main(args):
     src_lang = args.train_src_languages.split('+')[0]
     tgt_lang = args.train_tgt_languages.split('+')[0]
 
+    # dump entities if required
+    if args.ned_dump_entity_type_pairs and args.add_entities_to_text == 'append':
+        for task, train_set, val_set in zip(tasks, train_sets, val_sets):
+            ned_dump_entity_type_pairs(train_set, args.data, 'train', task.utterance_field)
+            ned_dump_entity_type_pairs(val_set, args.data, 'eval', task.utterance_field)
+        return
+
     ########## initialize model
     best_decascore = None
     if args.load is not None:
@@ -679,12 +686,6 @@ def main(args):
     else:
         logger.info(f'Initializing a new {model_name}')
         model = model_class(args=args, vocab_sets=train_sets + val_sets, tasks=tasks, src_lang=src_lang, tgt_lang=tgt_lang)
-
-    # dump entities if required
-    if args.ned_dump_entity_type_pairs and args.add_entities_to_text == 'append':
-        for task, train_set, val_set in zip(tasks, train_sets, val_sets):
-            ned_dump_entity_type_pairs(train_set, args.data, 'train', task.utterance_field)
-            ned_dump_entity_type_pairs(val_set, args.data, 'eval', task.utterance_field)
 
     params = get_trainable_params(model)
     log_model_size(logger, model, model_name)

--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -664,7 +664,6 @@ def main(args):
         for task, train_set, val_set in zip(tasks, train_sets, val_sets):
             ned_dump_entity_type_pairs(train_set, args.data, 'train', task.utterance_field)
             ned_dump_entity_type_pairs(val_set, args.data, 'eval', task.utterance_field)
-        return
 
     ########## initialize model
     best_decascore = None

--- a/genienlp/util.py
+++ b/genienlp/util.py
@@ -294,16 +294,18 @@ def find_span_type(program, begin_index, end_index):
 
     return span_type, end_index
 
+
 def find_span(haystack, needle):
-    for i in range(len(haystack)-len(needle)+1):
+    for i in range(len(haystack) - len(needle) + 1):
         found = True
         for j in range(len(needle)):
-            if haystack[i+j] != needle[j]:
+            if haystack[i + j] != needle[j]:
                 found = False
                 break
         if found:
             return i
     return None
+
 
 def requote_program(program):
 

--- a/genienlp/util.py
+++ b/genienlp/util.py
@@ -294,6 +294,16 @@ def find_span_type(program, begin_index, end_index):
 
     return span_type, end_index
 
+def find_span(haystack, needle):
+    for i in range(len(haystack)-len(needle)+1):
+        found = True
+        for j in range(len(needle)):
+            if haystack[i+j] != needle[j]:
+                found = False
+                break
+        if found:
+            return i
+    return None
 
 def requote_program(program):
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setuptools.setup(
         'requests~=2.22',
         'num2words>=0.5.10',
         'dateparser>=1.0.0',
-        'datasets==1.17.0',
+        'datasets==1.18.0',
         'seqeval==1.2.2',
         'transformers==4.15.0',
         'sentence-transformers==2.1.0',


### PR DESCRIPTION
This PR reimplements the type mapping for bootleg, and redoes the analysis scripts.
I haven't touched the existing type mapping files. The PR depends on https://github.com/stanford-oval/thingpedia-common-devices/pull/458 as thingpedia-common-devices will be the new home of type mapping files. Most importantly, you need two separate type mapping files, one for bootleg and one for oracle.

Results are at https://docs.google.com/spreadsheets/d/159oZV2aE4Jy7lTzyweSIuy03tU4rh1HPPIr8M8A63wo/edit#gid=33582497
We get about 58% F1 on the training set and 76% F1 on the dev set.
Precision is in general very low, and particularly low on the training set, because there are many confounding entities: entities that are known to bootleg but not to the oracle (for example they appear in a search query).