### PR TITLE
Fix prediction bug in the `reverse_almond` task

### DIFF
--- a/genienlp/tasks/almond_task.py
+++ b/genienlp/tasks/almond_task.py
@@ -541,7 +541,7 @@ class ReverseAlmond(BaseAlmondTask):
 
     def __init__(self, name, args):
         super().__init__(name, args)
-        self._metrics = ['blue', 'em']
+        self._metrics = ['bleu', 'em']
 
     @property
     def utterance_field(self):

--- a/genienlp/util.py
+++ b/genienlp/util.py
@@ -938,6 +938,8 @@ def load_config_json(args):
                 setattr(args, r, 10000)
             elif r == 'label_smoothing':
                 setattr(args, r, 0.0)
+            elif r == 'min_output_length':
+                setattr(args, r, 3)
             elif r == 'no_separator':
                 setattr(args, r, True)  # old models don't use a separator
             else:


### PR DESCRIPTION
- Fixes a small type.
- Adds a default value for `--min_output_length` in `predict`.