### PR TITLE
Revert recent change in bart large config

### DIFF
--- a/genienlp/models/transformer_seq2seq.py
+++ b/genienlp/models/transformer_seq2seq.py
@@ -116,6 +116,9 @@ class TransformerSeq2Seq(GenieModelForGeneration):
             forced_bos_token_id = self.numericalizer._tokenizer.lang_code_to_id[tgt_lang]
             self.config.forced_bos_token_id = forced_bos_token_id
 
+        if self._is_bart_large:
+            self.config.forced_bos_token_id = None
+
     def forward(self, *input, **kwargs):
         if self.training or kwargs.get('train', False):
             batch = input[0]


### PR DESCRIPTION
HF recently added `forced_bos_token_id=0` to bart-large's config file (See [link](https://github.com/huggingface/transformers/issues/15559)). This breaks previously trained models that didn't have this token set (e.g. production models). For now, revert this change in our code until we figure a proper fix.