### PR TITLE
Change batching algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ pip install -e .  # -e means your changes to the code will automatically take ef
 
 After installation, `genienlp` command becomes available.
 
+Some GenieNLP commands have additional dependencies for plotting and entity detection. If you are using those commands, you can obtain their dependencies by running the following:
+
+```
+pip install matplotlib~=3.0 seaborn~=0.9
+python -m spacy download en_core_web_sm
+```
+
 ## Usage
 
 ### Training a semantic parser

--- a/genienlp/arguments.py
+++ b/genienlp/arguments.py
@@ -172,6 +172,13 @@ def parse_argv(parser):
         '--sentence_batching', action='store_true', help='Batch same sentences together (used for multilingual tasks)'
     )
     parser.add_argument(
+        '--train_batching_algorithm',
+        type=str,
+        default='sample',
+        choices=['sample', 'epoch'],
+        help='`sample` will sample batches from the training set but shorter examples will have a higher probability of being selected, `epoch` will sample but ensure that each training example is seen exactly N times before any example is seen N+1 times.',
+    )
+    parser.add_argument(
         '--use_encoder_loss',
         action='store_true',
         help='Force encoded values for sentences in different languages to be the same',

--- a/genienlp/data_utils/iterator.py
+++ b/genienlp/data_utils/iterator.py
@@ -31,6 +31,7 @@
 import logging
 import random
 
+import numpy as np
 import torch
 
 logger = logging.getLogger(__name__)
@@ -70,6 +71,7 @@ class LengthSortedIterator(torch.utils.data.Sampler):
             self.data_source, self.original_order = tuple(zip(*sorted_data_with_original_order))
         else:
             self.data_source, self.original_order = data_source, list(range(len(data_source)))
+        self.data_source_marked = np.zeros(shape=(len(self.data_source)))  # mark each example that has been used in a batch
         self.batch_size = batch_size  # number of examples or number of tokens
         self.shuffle_and_repeat = shuffle_and_repeat
         self.last_batch_start_index = 0
@@ -94,6 +96,7 @@ class LengthSortedIterator(torch.utils.data.Sampler):
 
     def __iter__(self):
         self.last_batch_start_index = 0
+        self.data_source_marked = np.zeros(shape=(len(self.data_source)))
         self.last_batch_start_index = self._get_next_batch_start_index()
         return self
 
@@ -108,6 +111,7 @@ class LengthSortedIterator(torch.utils.data.Sampler):
         while current_batch_size < self.batch_size:
             candidate_example = self.data_source[candidate_index]
             if self.batch_size_fn([candidate_example]) > self.batch_size:
+                # the example is too big even on its own
                 global _warned_for_batch_size
                 if self.no_skip:
                     raise ValueError(
@@ -118,8 +122,8 @@ class LengthSortedIterator(torch.utils.data.Sampler):
                         'Skipping an example larger than batch size. Consider increasing the batch size to avoid this warning'
                     )
                     _warned_for_batch_size = True
-                self.last_batch_start_index += 1
-                candidate_index += 1
+                self.last_batch_start_index = self._next_unmarked_index(self.last_batch_start_index)
+                candidate_index = self._next_unmarked_index(candidate_index)
                 if candidate_index >= len(self.data_source):
                     # This is the end of the iterator
                     assert not self.shuffle_and_repeat
@@ -134,8 +138,9 @@ class LengthSortedIterator(torch.utils.data.Sampler):
                 break
 
             batch_of_indices.append(candidate_index)
+            self.data_source_marked[candidate_index] = 1  # mark this index
             current_batch_size = candidate_batch_size
-            candidate_index += 1
+            candidate_index = self._next_unmarked_index(candidate_index)
 
             if candidate_index == len(self.data_source):
                 break  # don't start from i=0; there is a large difference between the length of the first and last element
@@ -143,9 +148,28 @@ class LengthSortedIterator(torch.utils.data.Sampler):
         self.last_batch_start_index += len(batch_of_indices)
         return batch_of_indices
 
+    def _unmarked_index_to_datasource_index(self, index: int) -> int:
+        return np.searchsorted(np.arange(0, len(self.data_source)) - np.cumsum(self.data_source_marked), index, side='left')
+
+    def _next_unmarked_index(self, index: int) -> int:
+        """
+        or stop at len(self.data_source)
+        """
+        index += 1
+        while index < len(self.data_source) and self.data_source_marked[index] == 1:
+            index += 1
+        return index
+
     def _get_next_batch_start_index(self):
         if self.shuffle_and_repeat:
+            examples_left_in_epoch = len(self.data_source) - np.sum(self.data_source_marked)
+            if examples_left_in_epoch == 0:
+                # start a new epoch
+                self.data_source_marked = np.zeros(shape=(len(self.data_source)))
+                examples_left_in_epoch = len(self.data_source)
             # if self.groups > 1, this ensures that the start of each batch is a multiply of self.groups, i.e. where a group starts
-            return random.randrange(0, len(self.data_source) / self.groups) * self.groups
+            start_idx = random.randrange(0, examples_left_in_epoch / self.groups) * self.groups
+            start_idx = self._unmarked_index_to_datasource_index(start_idx)
+            return start_idx
         else:
             return self.last_batch_start_index

--- a/genienlp/data_utils/iterator.py
+++ b/genienlp/data_utils/iterator.py
@@ -169,26 +169,21 @@ class LengthSortedIterator(torch.utils.data.Sampler):
         """
         or stop at len(self.data_source)
         """
-        a = index
         index += 1
         while index < len(self.data_source) and self.data_source_marked[index] == 1:
             index += 1
-        assert index == a + 1
         return index
 
     def _get_next_batch_start_index(self):
         if self.shuffle_and_repeat:
             examples_left_in_epoch = len(self.data_source) - np.sum(self.data_source_marked)
-            assert np.sum(self.data_source_marked) == 0
             if examples_left_in_epoch == 0:
                 # start a new epoch
                 self.data_source_marked = np.zeros(shape=(len(self.data_source)))
                 examples_left_in_epoch = len(self.data_source)
             # if self.groups > 1, this ensures that the start of each batch is a multiply of self.groups, i.e. where a group starts
             start_idx = random.randrange(0, examples_left_in_epoch / self.groups) * self.groups
-            a = start_idx
             start_idx = self._unmarked_index_to_datasource_index(start_idx)
-            assert a == start_idx
             return start_idx
         else:
             return self.last_batch_start_index

--- a/genienlp/data_utils/progbar.py
+++ b/genienlp/data_utils/progbar.py
@@ -78,7 +78,7 @@ def progress_bar(iterable, desc=None, total=None, disable=False):
     if sys.stderr.isatty():
         return tqdm(iterable, desc=desc, total=total)
     else:
-        return LogFriendlyProgressBar(iterable, desc=desc, total=total, step=5)
+        return LogFriendlyProgressBar(iterable, desc=desc, total=total, step=10)
 
 
 def prange(*args, desc=None, disable=False):

--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -229,7 +229,9 @@ def validate_while_training(task, val_iter, model, args, num_print=10):
             # get rid of the DataParallel wrapper
             model = model.module
 
-        validation_output = model.validate(val_iter, task)
+        validation_output = model.validate(
+            val_iter, task, disable_progbar=len(val_iter) < 500
+        )  # show progress bar if there are more than 500 batches in the validation set
 
         # loss is already calculated
         metrics_to_compute = [metric for metric in task.metrics if metric != 'loss']
@@ -445,7 +447,7 @@ def train(
         for task, dataset, tok in zip(args.train_tasks, train_sets, args.train_batch_tokens)
     ]
     t1 = time.time()
-    logger.info('Preparing iterators took {:.2f} seconds'.format(t1 - t0))
+    logger.info('Preparing train iterators took %d minutes and %.2f seconds', int((t1 - t0) // 60), (t1 - t0) % 60)
 
     train_iters = [(task, iter(train_iter)) for task, train_iter in train_iters]
     # save memory

--- a/genienlp/train.py
+++ b/genienlp/train.py
@@ -443,7 +443,12 @@ def train(
 
     t0 = time.time()
     train_iters = [
-        (task, make_data_loader(dataset, numericalizer, tok, main_device, train=True))
+        (
+            task,
+            make_data_loader(
+                dataset, numericalizer, tok, main_device, train=True, batching_algorithm=args.train_batching_algorithm
+            ),
+        )
         for task, dataset, tok in zip(args.train_tasks, train_sets, args.train_batch_tokens)
     ]
     t1 = time.time()
@@ -454,7 +459,10 @@ def train(
     del train_sets
 
     val_iters = [
-        (task, make_data_loader(dataset, numericalizer, bs, main_device, train=False))
+        (
+            task,
+            make_data_loader(dataset, numericalizer, bs, main_device, train=False),
+        )  # no need to specify batching_algorithm for validation sets
         for task, dataset, bs in zip(args.val_tasks, val_sets, args.val_batch_size)
     ]
     # save memory
@@ -463,7 +471,12 @@ def train(
     aux_iters = []
     if use_curriculum:
         aux_iters = [
-            (name, make_data_loader(dataset, numericalizer, tok, main_device, train=True))
+            (
+                name,
+                make_data_loader(
+                    dataset, numericalizer, tok, main_device, train=True, batching_algorithm=args.train_batching_algorithm
+                ),
+            )
             for name, dataset, tok in zip(args.train_tasks, aux_sets, args.train_batch_tokens)
         ]
         aux_iters = [(task, iter(aux_iter)) for task, aux_iter in aux_iters]

--- a/genienlp/util.py
+++ b/genienlp/util.py
@@ -307,7 +307,9 @@ def elapsed_time(log):
     return f'{day:02}:{hour:02}:{minutes:02}:{seconds:02}'
 
 
-def make_data_loader(dataset, numericalizer, batch_size, device=None, train=False, return_original_order=False):
+def make_data_loader(
+    dataset, numericalizer, batch_size, device=None, train=False, return_original_order=False, batching_algorithm='sample'
+):
     args = numericalizer.args
     all_features = NumericalizedExamples.from_examples(dataset, numericalizer)
 
@@ -386,6 +388,7 @@ def make_data_loader(dataset, numericalizer, batch_size, device=None, train=Fals
         sort_key_fn=sort_key_fn,
         batch_size_fn=batch_size_fn,
         groups=dataset.groups,
+        batching_algorithm=batching_algorithm,
     )
     # get the sorted data_source
     all_f = sampler.data_source

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -21,5 +21,5 @@ export SENTENCE_TRANSFORMERS_HOME="$EMBEDDING_DIR"
 export SHARED_TRAIN_HPARAMS="--embeddings $EMBEDDING_DIR --exist_ok --no_commit --preserve_case --save_every 2 --log_every 2 --val_every 2"
 
 TMPDIR=`pwd`
-workdir=`mktemp -d $TMPDIR/genieNLP-tests-XXXXXX`
+workdir=`mktemp -d $TMPDIR/genieNLP-tests-XXXXX`
 trap on_error ERR INT TERM

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -16,6 +16,8 @@ else
   EMBEDDING_DIR="$SRCDIR/embeddings"
 fi
 
+# Test on CPU. Model outputs will be slightly different on GPU, so the tests that check model outputs will fail.
+export CUDA_VISIBLE_DEVICES=""
 export SENTENCE_TRANSFORMERS_HOME="$EMBEDDING_DIR"
 # parameters that are commonly passed to `genienlp train` test cases
 export SHARED_TRAIN_HPARAMS="--embeddings $EMBEDDING_DIR --exist_ok --no_commit --preserve_case --save_every 2 --log_every 2 --val_every 2"

--- a/tests/test_main_almond.sh
+++ b/tests/test_main_almond.sh
@@ -8,7 +8,7 @@ for hparams in \
   "--model TransformerSeq2Seq --pretrained_model sshleifer/bart-tiny-random" \
   "--model TransformerSeq2Seq --pretrained_model sshleifer/bart-tiny-random --preprocess_special_tokens --almond_detokenize_sentence" \
   "--model TransformerLSTM --pretrained_model bert-base-cased --min_output_length 2 --trainable_decoder_embeddings=50 --num_beams 4 --num_beam_groups 4 --num_outputs 4 --diversity_penalty 1.0" \
-  "--model TransformerLSTM --pretrained_model bert-base-cased --min_output_length 2 --trainable_decoder_embeddings=50  --override_question ." \
+  "--model TransformerLSTM --pretrained_model bert-base-cased --min_output_length 2 --trainable_decoder_embeddings=50  --override_question . --train_batching_algorithm epoch" \
   "--model TransformerLSTM --pretrained_model xlm-roberta-base --min_output_length 2 --trainable_decoder_embeddings=50 --eval_set_name aux" \
   "--model TransformerSeq2Seq --pretrained_model sshleifer/bart-tiny-random --preprocess_special_tokens --min_output_length 2 --num_beams 4 --num_beam_groups 1 --num_outputs 4" ;
 do


### PR DESCRIPTION
- Change batching algorithm
**This change does not affect the quality of trained models, but will make them not directly comparable to previous versions due to different randomness.**
Before this change, we would sort the training data by their size (e.g. number of tokens in the input and output) and then sample from this sorted list by picking a starting index and adding subsequent examples to the batch until the batch is full. This was done so that we can group examples of similar size into the same batch, and decrease wasted GPU computations by decreasing the number of needed pad tokens.
This had two downsides:
1.  It was not guaranteed that we will see every training example the same number of times during training. While acceptable in theory and especially large synthetic datasets, not seeing every training example is not desirable in general.
1.  This sampling algorithm actually favors smaller examples, since batches containing smaller examples contain more examples.

In this PR, we fix these two, while maintaining the speedup from batching examples of similar size together. We see every training example exactly `n` times before we see any example `n+1` times. I also tested that the training speed stays the same after this change.
This is done by "marking" seen examples in each epoch, and only sampling from the unmarked examples. Marks get cleared after the epoch ends.

- Add documentation for optional dependencies
- Add progress bar for when the validation dataset is large